### PR TITLE
Flesh out docstrings in source

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E203, E722, W503
+max-line-length = 120

--- a/perform/constants.py
+++ b/perform/constants.py
@@ -1,4 +1,5 @@
-# useful constants used throughout the code
+"""Useful constants used throughout the code"""
+
 import numpy as np
 
 # Precision of real and complex numbers

--- a/perform/driver.py
+++ b/perform/driver.py
@@ -1,3 +1,13 @@
+"""Driver for executing PERFORM simulations.
+
+Initializes all necessary constructs for executing a PERFORM simulation,
+namely a SystemSolver, a SolutionDomain, a VisualizationGroup, and a RomDomain (if running a ROM simulation).
+Advances through time steps, calls visualization and output routines, and handles solver blowup if it occurs.
+
+After installing PERFORM, the terminal command "perform" will execute main() and take the first command line
+argument as the working directory
+"""
+
 import os
 from time import time
 import argparse
@@ -13,6 +23,7 @@ warnings.filterwarnings("error")
 
 
 def main():
+    """Main driver function which initializes all necessary constructs and advances the solution in time"""
 
     # ----- Start setup -----
 

--- a/perform/flux/flux.py
+++ b/perform/flux/flux.py
@@ -1,9 +1,12 @@
 class Flux:
+    """Base class for any flux scheme, either viscous or inviscid.
+    
+    Child classes must implement the following member functions:
+    * calc_flux()
+    * calc_jacob_prim()
     """
-    Base class for any flux scheme, either viscous or inviscid
 
-    NOTE: not really sure this is necessary
-    """
+    # NOTE: not really sure this is necessary
 
     def __init__(self):
 

--- a/perform/flux/flux.py
+++ b/perform/flux/flux.py
@@ -1,6 +1,6 @@
 class Flux:
     """Base class for any flux scheme, either viscous or inviscid.
-    
+
     Child classes must implement the following member functions:
     * calc_flux()
     * calc_jacob_prim()

--- a/perform/flux/invisc_flux/invisc_flux.py
+++ b/perform/flux/invisc_flux/invisc_flux.py
@@ -5,19 +5,51 @@ from perform.flux.flux import Flux
 
 
 class InviscFlux(Flux):
-    """
-    Base class for any inviscid flux scheme
+    """Base class for all inviscid flux schemes.
+
+    Simply provides member functions to compute the analytical inviscid flux vector and its Jacobians.
+
+    Child classes must provide the following member functions:
+    * calc_flux()
+    * calc_jacob_prim()
     """
 
     def __init__(self):
 
         pass
 
-    def calc_d_inv_flux_d_sol_prim(self, sol):
-        """
-        Compute Jacobian of inviscid flux vector with respect to primitive state
+    def calc_inv_flux(self, sol_cons, sol_prim, h0):
+        """Compute inviscid flux vector
 
-        Here, sol should be the SolutionPhys associated with a face state
+        Args:
+            sol_cons: NumPy array of the conservative solution profile.
+            sol_prim: NumPy array of the primitive solution profile.
+            h0: NumPy array of the stagnation enthalpy profile.
+
+        Returns:
+            NumPy array of the inviscid flux profile.
+        """
+
+        flux = np.zeros(sol_cons.shape, dtype=REAL_TYPE)
+
+        flux[0, :] = sol_cons[1, :]
+        flux[1, :] = sol_cons[1, :] * sol_prim[1, :] + sol_prim[0, :]
+        flux[2, :] = sol_cons[0, :] * h0 * sol_prim[1, :]
+        flux[3:, :] = sol_cons[3:, :] * sol_prim[[1], :]
+
+        return flux
+
+    def calc_d_inv_flux_d_sol_prim(self, sol):
+        """Compute Jacobian of inviscid flux vector with respect to primitive state.
+
+        Here, sol should be the SolutionPhys associated with a reconstructed face state.
+        The Jacobian is computed analytically, please refer to the solver theory documentation for more details.
+
+        Args:
+            sol: SolutionPhys representing the left or right reconstructed face state.
+
+        Returns:
+            3D NumPy array of the inviscid flux vector Jacobian.
         """
 
         gas = sol.gas_model

--- a/perform/flux/invisc_flux/roe_invisc_flux.py
+++ b/perform/flux/invisc_flux/roe_invisc_flux.py
@@ -126,21 +126,17 @@ class RoeInviscFlux(InviscFlux):
 
         # Derivatives of density and enthalpy
         (d_rho_d_press, d_rho_d_temp, d_rho_d_mass_frac) = gas_model.calc_dens_derivs(
-            sol_ave.sol_cons[0, :],
+            rho,
             wrt_press=True,
-            pressure=sol_ave.sol_prim[0, :],
+            pressure=press,
             wrt_temp=True,
-            temperature=sol_ave.sol_prim[2, :],
+            temperature=temp,
             wrt_spec=True,
             mix_mol_weight=sol_ave.mw_mix,
         )
 
         (d_enth_d_press, d_enth_d_temp, d_enth_d_mass_frac) = gas_model.calc_stag_enth_derivs(
-            wrt_press=True,
-            wrt_temp=True,
-            mass_fracs=sol_ave.sol_prim[3:, :],
-            wrt_spec=True,
-            temperature=sol_ave.sol_prim[2, :],
+            wrt_press=True, wrt_temp=True, mass_fracs=mass_fracs, wrt_spec=True, temperature=temp,
         )
 
         # Save for Jacobian calculations

--- a/perform/flux/visc_flux/standard_visc_flux.py
+++ b/perform/flux/visc_flux/standard_visc_flux.py
@@ -6,7 +6,7 @@ from perform.flux.flux import Flux
 
 class StandardViscFlux(Flux):
     """Standard viscous flux scheme with binary diffusion velocity approximation
-    
+
     Inherits from Flux.
 
     Args:
@@ -20,7 +20,7 @@ class StandardViscFlux(Flux):
     def calc_flux(self, sol_domain):
         """Compute viscous flux vector.
 
-        Computes state gradient at cell faces and computes viscous flux with respect to average face state. 
+        Computes state gradient at cell faces and computes viscous flux with respect to average face state.
         Assumes that average face state has already been computed.
 
         Args:

--- a/perform/gas_model/calorically_perfect_gas.py
+++ b/perform/gas_model/calorically_perfect_gas.py
@@ -99,7 +99,7 @@ class CaloricallyPerfectGas(GasModel):
 
     def calc_mix_enth_ref(self, mass_fracs):
         """Compute mixture reference enthalpy.
-        
+
         Args:
             mass_fracs: NumPy array of mass fraction profiles. Accepts num_species or num_species_full profiles.
 
@@ -164,7 +164,7 @@ class CaloricallyPerfectGas(GasModel):
 
     def calc_spec_enth(self, temperature):
         """Compute individual enthalpies for all num_species_full species.
-        
+
         Args:
             temperature: NumPy array of the temperature field.
 
@@ -293,7 +293,7 @@ class CaloricallyPerfectGas(GasModel):
 
     def calc_species_therm_cond(self, spec_dyn_visc=None, temperature=None):
         """Compute species thermal conductivities for all num_species_full species.
-        
+
         Args:
             spec_dyn_visc:
                 NumPy array of the species dynamic viscosity profiles.
@@ -366,7 +366,7 @@ class CaloricallyPerfectGas(GasModel):
 
     def calc_species_mass_diff_coeff(self, density, spec_dyn_visc=None, temperature=None):
         """Compute mass diffusivity coefficient of species into mixture for all num_species_full species.
-        
+
         Args:
             density: NumPy array of the density profile.
             spec_dyn_visc:
@@ -392,7 +392,8 @@ class CaloricallyPerfectGas(GasModel):
 
         Args:
             temperature: NumPy array of the temperature profile.
-            r_mix: NumPy array of the mixture specific gas constant profile. If not provided, calculated from mass_fracs.
+            r_mix:
+                NumPy array of the mixture specific gas constant profile. If not provided, calculated from mass_fracs.
             gamma_mix: NumPy array of mixture ratio of specific heats. If not provided, calculated from mass_fracs.
             mass_fracs:
                 NumPy array of mass fraction profiles. Accepts num_species or num_species_full profiles.
@@ -445,12 +446,12 @@ class CaloricallyPerfectGas(GasModel):
         mass_fracs=None,
     ):
         """Compute derivatives of density with respect to pressure, temperature, or species mass fraction.
-        
+
         For species derivatives, returns num_species derivatives. For derivation of analytical derivatives,
         please refer to the solver theory documentation.
 
         Args:
-            density: 
+            density: NumPy array of density profile.
             wrt_press: Boolean flag indicating whether derivatives with respect to pressure should be computed.
             pressure: NumPy array of the pressure profile. Required if wrt_press=True.
             wrt_temp: Boolean flag indicating whether derivatives with respect to temperature should be computed.
@@ -513,10 +514,10 @@ class CaloricallyPerfectGas(GasModel):
         temperature=None,
     ):
         """Compute derivatives of stagnation enthalpy w/r/t pressure, temperature, velocity, or species mass fraction.
-        
+
         For species derivatives, returns num_species derivatives. For derivation of analytical derivatives,
         please refer to the solver theory documentation.
-        
+
         Args:
             wrt_press: Boolean flag indicating whether derivatives with respect to pressure should be computed.
             wrt_temp: Boolean flag indicating whether derivatives with respect to temperature should be computed.

--- a/perform/gas_model/calorically_perfect_gas.py
+++ b/perform/gas_model/calorically_perfect_gas.py
@@ -79,7 +79,7 @@ class CaloricallyPerfectGas(GasModel):
             mass_fracs_ns = mass_fracs
 
         r_mix = R_UNIV * ((1.0 / self.mol_weights[-1]) + np.sum(mass_fracs_ns * self.mw_inv_diffs[:, None], axis=0))
-        
+
         return r_mix
 
     def calc_mix_gamma(self, r_mix, cp_mix):
@@ -94,7 +94,7 @@ class CaloricallyPerfectGas(GasModel):
         """
 
         gamma_mix = cp_mix / (cp_mix - r_mix)
-        
+
         return gamma_mix
 
     def calc_mix_enth_ref(self, mass_fracs):
@@ -112,9 +112,9 @@ class CaloricallyPerfectGas(GasModel):
             mass_fracs_ns = self.get_mass_frac_array(mass_fracs_in=mass_fracs)
         else:
             mass_fracs_ns = mass_fracs
-        
+
         enth_ref_mix = self.enth_ref[-1] + np.sum(mass_fracs_ns * self.enth_ref_diffs[:, None], axis=0)
-        
+
         return enth_ref_mix
 
     def calc_mix_cp(self, mass_fracs):
@@ -132,9 +132,9 @@ class CaloricallyPerfectGas(GasModel):
             mass_fracs_ns = self.get_mass_frac_array(mass_fracs_in=mass_fracs)
         else:
             mass_fracs_ns = mass_fracs
-        
+
         cp_mix = self.cp[-1] + np.sum(mass_fracs_ns * self.cp_diffs[:, None], axis=0)
-        
+
         return cp_mix
 
     def calc_density(self, sol_prim, r_mix=None):

--- a/perform/gas_model/gas_model.py
+++ b/perform/gas_model/gas_model.py
@@ -7,27 +7,66 @@ from perform.constants import REAL_TYPE, R_UNIV
 
 
 class GasModel:
-    """
-    Base class storing constant chemical properties of modeled species
-    Also includes universal gas methods (e.g. calc mixture molecular weight)
+    """Base class for all gas models (e.g. CPG, TPG).
+    
+    GasModel reads various universal gas properties (e.g. species molecular weights) from the chemistry input file
+    and implements several universal gas methods (e.g. calculating mixture molecular weight).
+
+    Child classes must implement the following member methods:
+
+    * calc_mix_gas_constant()
+    * calc_mix_gamma()
+    * calc_mix_cp()
+    * calc_spec_enth()
+    * calc_stag_enth()
+    * calc_species_dynamic_visc()
+    * calc_mix_dynamic_visc()
+    * calc_species_therm_cond()
+    * calc_mix_thermal_cond()
+    * calc_species_mass_diff_coeff()
+    * calc_sound_speed()
+    * calc_dens_derivs()
+    * calc_stag_enth_derivs()
+    
+    See calorically_perfect_gas.py for details on each.
+
+    Args:
+        chem_dict: Dictionary of input parameters read from chemistry file.
+
+    Attributes:
+        num_species_full: Total number of chemical species to be modeled.
+        num_species: If num_species_full == 1, num_species == 1. Otherwise, num_species == num_species_full - 1
+        species_names:
+            List of strings, names of chemical species. If not provided by user, defaults to "Species X",
+            where X is the species index.
+        mol_weights: NumPy array of chemical species molecular weights in g/mol
+        mass_frac_slice: Range for slicing mass fraction arrays, avoids issues when num_species_full == 1
+        mw_inv: NumPy array of reciprocals of molecular weights, used in some calculations
+        mw_inv_diffs:
+            NumPy array of difference in molecular weights between the first num_species species and the last species,
+            used in some calculations.
+        num_eqs:
+            Number of governing equations in system.
+            Equal to 3 + num_species (continuity, momentum, energy, and species transport).
+        mix_mass_matrix: NumPy array used in computing mixture dynamic viscosity.
+        mix_inv_mass_matrix: NumPy array used in computing mixture dynamic viscosity.
     """
 
-    def __init__(self, gas_dict):
+    def __init__(self, chem_dict):
 
         # Gas composition
-        self.num_species_full = int(gas_dict["num_species"])
-        self.mol_weights = gas_dict["mol_weights"].astype(REAL_TYPE)
+        self.num_species_full = int(chem_dict["num_species"])
+        self.mol_weights = chem_dict["mol_weights"].astype(REAL_TYPE)
 
         # Species names for plotting and output
         try:
-            self.species_names = gas_dict["species_names"]
+            self.species_names = chem_dict["species_names"]
             assert len(self.species_names) == self.num_species_full
         except KeyError:
             self.species_names = ["Species_" + str(x + 1) for x in range(self.num_species_full)]
 
         # Check input lengths
         assert len(self.mol_weights) == self.num_species_full
-        # TODO: check lengths of reaction inputs
 
         # Dealing with single-species option
         if self.num_species_full == 1:
@@ -41,34 +80,40 @@ class GasModel:
 
         self.num_eqs = self.num_species + 3
 
-        # Mass matrices for calculating
-        # 	viscosity and thermal conductivity mixing laws
+        # Mass matrices for calculating viscosity and thermal conductivity mixing laws
         self.mix_mass_matrix = np.zeros((self.num_species_full, self.num_species_full), dtype=REAL_TYPE)
         self.mix_inv_mass_matrix = np.zeros((self.num_species_full, self.num_species_full), dtype=REAL_TYPE)
-        self.precomp_mix_mass_matrices()
-
-    def precomp_mix_mass_matrices(self):
-        """
-        Precompute mass matrices for dynamic viscosity mixing law
-        """
-
         for spec_idx in range(self.num_species_full):
             self.mix_mass_matrix[spec_idx, :] = np.power((self.mol_weights / self.mol_weights[spec_idx]), 0.25)
             self.mix_inv_mass_matrix[spec_idx, :] = (1.0 / (2.0 * np.sqrt(2.0))) * (
                 1.0 / np.sqrt(1.0 + self.mol_weights[spec_idx] / self.mol_weights)
             )
 
-    def get_mass_frac_array(self, sol_prim=None, mass_fracs=None):
-        """
-        Helper function to handle array slicing
-        to avoid weird NumPy array broadcasting issues
+    def get_mass_frac_array(self, sol_prim_in=None, mass_fracs_in=None):
+        """Helper function to get num_species mass fraction vectors.
+        
+        This function helps to avoid weird NumPy array broadcasting issues, namely the automatic
+        squeezing of singleton dimensions. Can retrieve num_species mass fraction fields from
+        sol_prim_in or mass_fracs_in.
+
+        Args:
+            sol_prim_in:
+                NumPy array of primitive solution profile (e.g. from SolutionPhys),
+                including pressure, velocity, temperature, and species mass fractions.
+            mass_fracs_in:
+                NumPy array of species mass fractions. May pass array of num_species or num_species_full profiles.
+
+        Returns:
+            NumPy array containing num_species mass fraction profiles.
         """
 
         # Get all but last mass fraction field
-        if sol_prim is None:
-            assert mass_fracs is not None, "Must provide mass fractions if not providing primitive solution"
-            if mass_fracs.ndim == 1:
-                mass_fracs = np.reshape(mass_fracs, (1, -1))
+        if sol_prim_in is None:
+            assert mass_fracs_in is not None, "Must provide mass fractions if not providing primitive solution"
+            if mass_fracs_in.ndim == 1:
+                mass_fracs = np.reshape(mass_fracs_in, (1, -1)).copy()
+            else:
+                mass_fracs = mass_fracs_in.copy()
 
             if mass_fracs.shape[0] == self.num_species_full:
                 mass_fracs = mass_fracs[self.mass_frac_slice, :]
@@ -77,16 +122,28 @@ class GasModel:
                     mass_fracs.shape[0] == self.num_species
                 ), "If not passing full mass fraction array, must pass N-1 species"
         else:
-            mass_fracs = sol_prim[3:, :]
+            assert sol_prim_in is not None, "Must provide primitive solution if not providing mass fractions"
+            mass_fracs = sol_prim_in[3:, :].copy()
 
         return mass_fracs
 
     def calc_all_mass_fracs(self, mass_fracs_ns, threshold=True):
-        """
-        Helper function to compute all num_species_full
-        mass fraction fields from num_species fields
+        """Helper function to compute all num_species_full mass fraction fields.
 
-        Thresholds all mass fraction fields between zero and unity
+        This function takes advantage of the fact that all species mass fractions at a given location must be equal
+        to unity. Thus, the mass fraction of the last chemical species (which is not directly modeled) is equal to
+        unity minus the sum of the other mass fractions. 
+        
+        Additionally, if threshold=True, all mass fraction fields are thresholded between zero and unity.
+
+        In the case num_species_full == 1, simply thesholds between zero and unity.
+
+        Args:
+            mass_fracs_ns: NumPy array of num_species mass fraction fields.
+            threshold: Boolean flag indicating whether to threshold all species mass fractions between zero and unity.
+
+        Returns:
+            NumPy array of num_species_full mass fraction fields, all summing to unity in each row.
         """
 
         if self.num_species_full == 1:
@@ -109,8 +166,15 @@ class GasModel:
         return mass_fracs
 
     def calc_mix_mol_weight(self, mass_fracs):
-        """
-        Compute mixture molecular weight
+        """Compute mixture molecular weights.
+
+        Args:
+            mass_fracs:
+                NumPy array of species mass fraction fields. If num_species fields provided, calculates the final
+                num_species_full-th mass fraction field.
+
+        Returns:
+            NumPy array of mixture molecular weights.
         """
 
         if mass_fracs.shape[0] == self.num_species:
@@ -121,8 +185,16 @@ class GasModel:
         return mix_mol_weight
 
     def calc_all_mole_fracs(self, mass_fracs, mix_mol_weight=None):
-        """
-        Compute mole fractions of all species from mass fractions
+        """Compute species mole fractions of all species.
+
+        Args:
+            mass_fracs:
+                NumPy array of species mass fraction fields. If num_species fields provided, calculates the final
+                num_species_full-th mass fraction field.
+            mix_mol_weight: Mixture molecular weight. If not provided, is calculated.
+
+        Returns:
+            NumPy array of mole fraction fields for all num_species_full chemical species.
         """
 
         if mass_fracs.shape[0] == self.num_species:

--- a/perform/gas_model/gas_model.py
+++ b/perform/gas_model/gas_model.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from perform.constants import REAL_TYPE, R_UNIV
+from perform.constants import REAL_TYPE
 
 # TODO: some of the CPG functions can be generalized and placed here
 # 	(e.g. calc sound speed in terms of enthalpy and density derivs)
@@ -8,7 +8,7 @@ from perform.constants import REAL_TYPE, R_UNIV
 
 class GasModel:
     """Base class for all gas models (e.g. CPG, TPG).
-    
+
     GasModel reads various universal gas properties (e.g. species molecular weights) from the chemistry input file
     and implements several universal gas methods (e.g. calculating mixture molecular weight).
 
@@ -27,7 +27,7 @@ class GasModel:
     * calc_sound_speed()
     * calc_dens_derivs()
     * calc_stag_enth_derivs()
-    
+
     See calorically_perfect_gas.py for details on each.
 
     Args:
@@ -91,7 +91,7 @@ class GasModel:
 
     def get_mass_frac_array(self, sol_prim_in=None, mass_fracs_in=None):
         """Helper function to get num_species mass fraction vectors.
-        
+
         This function helps to avoid weird NumPy array broadcasting issues, namely the automatic
         squeezing of singleton dimensions. Can retrieve num_species mass fraction fields from
         sol_prim_in or mass_fracs_in.
@@ -132,8 +132,8 @@ class GasModel:
 
         This function takes advantage of the fact that all species mass fractions at a given location must be equal
         to unity. Thus, the mass fraction of the last chemical species (which is not directly modeled) is equal to
-        unity minus the sum of the other mass fractions. 
-        
+        unity minus the sum of the other mass fractions.
+
         Additionally, if threshold=True, all mass fraction fields are thresholded between zero and unity.
 
         In the case num_species_full == 1, simply thesholds between zero and unity.

--- a/perform/input_funcs.py
+++ b/perform/input_funcs.py
@@ -10,7 +10,7 @@ from perform.constants import REAL_TYPE
 
 def catch_input(in_dict, in_key, default_val):
     """Handle non-list dictionary entries from parameter input files.
-    
+
     Casts input value as same type as default_val.
     Assign default values if user does not provide a given input parameter.
     Use catch_list() if attempting to retrieve lists or lists of lists.
@@ -48,7 +48,7 @@ def catch_input(in_dict, in_key, default_val):
 
 def catch_list(in_dict, in_key, default, len_highest=1):
     """Handle list and list of list dictionary entries from parameter input files.
-    
+
     Casts list entries of input as same type as default_val.
     Assign default values if user does not provide a given input parameter.
 

--- a/perform/input_funcs.py
+++ b/perform/input_funcs.py
@@ -1,3 +1,5 @@
+"""Functions for handling ingestion of input files"""
+
 import os
 import re
 
@@ -7,42 +9,64 @@ from perform.constants import REAL_TYPE
 
 
 def catch_input(in_dict, in_key, default_val):
-    """
-    Assign default values if user does not provide a certain input
+    """Handle non-list dictionary entries from parameter input files.
+    
+    Casts input value as same type as default_val.
+    Assign default values if user does not provide a given input parameter.
+    Use catch_list() if attempting to retrieve lists or lists of lists.
+
+    Args:
+        in_dict: Dictionary in input parameters, within which in_key is a key.
+        in_key: Key of parameter to retrieve from in_dict.
+        default:
+            Default value to assign at output if in_key does not exist in in_dict.
+            The type of default implicitly defines the type which the parameter
+            is cast to, if it exists in in_dict.
+    Returns:
+        Input parameter retrieved from in_dict, or default if not provided.
     """
 
     # TODO: correct error handling if default type is not recognized
-    # TODO: check against lowercase'd strings
-    # 		so that inputs are not case sensitive.
-    # 		Do this for True/False too
-    # TODO: instead of trusting user for None,
-    # 		could also use NaN/Inf to indicate int/float defaults
-    # 		without passing a numerical default
-    # 		Or could just pass the actual default type lol, that'd be easier
+    # TODO: check against lowercase'd strings so that inputs are not case sensitive.
+    # Do this for True/False too
+    # TODO: instead of trusting user for None, could also use NaN/Inf to indicate int/float defaults
+    # without passing a numerical default
+    # Or could just pass the actual default type lol, that'd be easier
 
     try:
         # If None passed as default, trust user
         if default_val is None:
-            outVal = in_dict[in_key]
+            out_val = in_dict[in_key]
         else:
             default_type = type(default_val)
-            outVal = default_type(in_dict[in_key])
+            out_val = default_type(in_dict[in_key])
     except KeyError:
-        outVal = default_val
+        out_val = default_val
 
-    return outVal
+    return out_val
 
 
 def catch_list(in_dict, in_key, default, len_highest=1):
-    """
-    Input processor for reading lists or lists of lists
-    Default defines length of lists at lowest level
+    """Handle list and list of list dictionary entries from parameter input files.
+    
+    Casts list entries of input as same type as default_val.
+    Assign default values if user does not provide a given input parameter.
+
+    Args:
+        in_dict: Dictionary in input parameters, within which in_key is a key.
+        in_key: Key of parameter to retrieve from in_dict.
+        default:
+            Default list to assign at output if in_key does not exist in in_dict.
+            The type of the list entries in default implicitly defines the type which the parameter
+            is cast to, if it exists in in_dict.
+        len_highest: Expected length of topmost list.
+
+    Returns:
+        Input parameter list retrieved from in_dict, or default if not provided.
     """
 
-    # TODO: needs to throw an error if input list of lists
-    # 	is longer than len_highest
-    # TODO: could make a recursive function probably,
-    # 	just hard to define appropriate list lengths at each level
+    # TODO: needs to throw an error if input list of lists is longer than len_highest
+    # TODO: could make a recursive function probably, just hard to define appropriate list lengths at each level
 
     list_of_lists_flag = type(default[0]) == list
 
@@ -85,8 +109,13 @@ def catch_list(in_dict, in_key, default, len_highest=1):
 
 
 def parse_value(expr):
-    """
-    Parse read text value into dict value
+    """Parse text into Python expression.
+
+    Args:
+        expr: String to be converted to Python expression (e.g. a list).
+
+    Returns:
+        Parsed Python expression.
     """
 
     try:
@@ -98,8 +127,18 @@ def parse_value(expr):
 
 
 def parse_line(line):
-    """
-    Parse read text line into dict key and value
+    """Parse line from text file line into dict key and value.
+
+    Breaks a line into the text before and after an equals sign, if present.
+    The text before the equals sign is treated as the parameter name,
+    and the text after the equals sign is the input value of this parameter.
+
+    Args:
+        line: String of a single line from text file.
+
+    Returns:
+        Dictionary key and value for input parameter read from line, if line contains a valid parameter.
+        Otherwise raises an exception (e.g. for empty lines, or lines without an equals sign)
     """
 
     eq = line.find("=")
@@ -111,8 +150,15 @@ def parse_line(line):
 
 
 def read_input_file(input_file):
-    """
-    Read input file
+    """Parse input parameters from PERFORM text input file.
+
+    Refer to the documentation for proper formatting of input files.
+
+    Args:
+        input_file: Path to input file to be read.
+
+    Returns:
+        Dictionary of parameters read from input_file.
     """
 
     # TODO: better exception handling besides just a pass
@@ -135,8 +181,18 @@ def read_input_file(input_file):
 
 
 def parse_bc(bc_name, in_dict):
-    """
-    Parse boundary condition parameters from the input parameter dictionary
+    """Parse boundary condition parameters from input parameter dictionary.
+
+    Retrieves inlet and outlet boundary condition parameters. Refer to the documentation
+    for proper formatting of these input parameters.
+
+    Args:
+        bc_name: "inlet" or "outlet", for inlet and outlet boundary condition, respectively.
+        in_dict: Dictionary if input parameters read from the solver parameters input file.
+
+    Returns:
+        Boundary condition parameters. If a given parameter is not supplied in the solver parameters input file,
+        then None is returned for that parameter.
     """
 
     # TODO: can definitely be made more general
@@ -178,9 +234,18 @@ def parse_bc(bc_name, in_dict):
 
 
 def get_initial_conditions(sol_domain, solver):
-    """
-    Extract initial condition profile from
-    two-zone initParamsFile, init_file .npy file, or restart file
+    """Extract initial condition primitive solution profile.
+
+    This function sets the initial conditions for a simulation. This may come from a piecewise uniform profile
+    file (init_params_file), a user-specified binary profile (init_file), or a restart files.
+
+    Restart files take precedence over an init_file, and an init_file takes precedence over an init_params_file file.
+
+    Args:
+        sol_domain: SolutionDomain for which the initial condition is retrieved.
+        solver: SystemSolver containing global simulation parameters.
+    Returns:
+        NumPy array of the initial condition primitive solution profile.
     """
 
     # TODO: add option to interpolate solution onto given mesh, if different
@@ -206,8 +271,16 @@ def get_initial_conditions(sol_domain, solver):
 
 
 def gen_piecewise_uniform_ic(sol_domain, solver):
-    """
-    Generate "left" and "right" states
+    """Get primitive solution profile initial condition from piecewise uniform parameters.
+
+    Piecewise uniform profiles are characterized by a solution profile broken into constant chunks,
+    like step functions. This can be useful for cases like a shock tube or initializing flame simulations.
+
+    Args:
+        sol_domain:
+        solver: SystemSolver containing global simulation parameters.
+    Returns:
+        NumPy array of the initial condition primitive solution profile.
     """
 
     # TODO: generalize to >2 uniform regions
@@ -250,12 +323,19 @@ def gen_piecewise_uniform_ic(sol_domain, solver):
 
 
 def read_restart_file(solver):
-    """
-    Read solution state from restart file
-    """
+    """Get primitive solution profile initial condition from a restart file.
 
-    # TODO: if higher-order multistep scheme,
-    # 	load previous time steps to preserve time accuracy
+    Also retrieves physical solution time to ensure boundary forcing function is correctly synced.
+
+    Sets solver.restart_iter so that subsequent restart files follow this restart file's iteration number.
+
+    Args:
+        solver: SystemSolver containing global simulation parameters.
+
+    Returns:
+        Solution time (in seconds), NumPy array of the loaded primitive solution profile,
+        and the current restart iteration number.
+    """
 
     # Read text file for restart file iteration number
     iter_file = os.path.join(solver.restart_output_dir, "restart_iter.dat")

--- a/perform/limiter/barth_jesp_limiter.py
+++ b/perform/limiter/barth_jesp_limiter.py
@@ -5,9 +5,10 @@ from perform.limiter.limiter import Limiter
 
 
 class BarthJespLimiter(Limiter):
-    """
-    Barth-Jespersen limiter
-    Ensures that no new minima or maxima are introduced in reconstruction
+    """Barth-Jespersen limiter.
+
+    This implements the limiter of Barth and Jespersen (1989) in one dimension.
+    Ensures that no new minima or maxima are introduced in reconstruction, but is non-differentiable.
     """
 
     def __init__(self):
@@ -15,8 +16,14 @@ class BarthJespLimiter(Limiter):
         super().__init__()
 
     def calc_limiter(self, sol_domain, grad):
-        """
-        Compute multiplicative limiter
+        """Compute multiplicative limiter.
+
+        Args:
+            sol_domain: SolutionDomain with which this Limiter is associated.
+            grad: NumPy array of the un-limited gradient directly computed from finite difference stencil.
+
+        Returns:
+            NumPy array of the multiplicative gradient limiter profile.
         """
 
         sol_prim = sol_domain.sol_prim_full[:, sol_domain.grad_idxs]

--- a/perform/limiter/limiter.py
+++ b/perform/limiter/limiter.py
@@ -4,7 +4,7 @@ import numpy as np
 class Limiter:
     """Base class for gradient limiters.
 
-    Simply provides some member functions which may be common to multiple child class limiters. 
+    Simply provides some member functions which may be common to multiple child class limiters.
 
     All child classes must implement the member method calc_limiter().
     """
@@ -15,7 +15,7 @@ class Limiter:
 
     def calc_neighbor_minmax(self, sol):
         """Find minimum and maximum of cell state and neighbor cell states
-        
+
         Args:
             sol:
                 2D NumPy array of a solution profile (e.g. SolutionPhys.sol_prim),

--- a/perform/limiter/limiter.py
+++ b/perform/limiter/limiter.py
@@ -2,8 +2,11 @@ import numpy as np
 
 
 class Limiter:
-    """
-    Base class for gradient limiters
+    """Base class for gradient limiters.
+
+    Simply provides some member functions which may be common to multiple child class limiters. 
+
+    All child classes must implement the member method calc_limiter().
     """
 
     def __init__(self):
@@ -11,8 +14,15 @@ class Limiter:
         pass
 
     def calc_neighbor_minmax(self, sol):
-        """
-        Find minimum and maximum of cell state and neighbor cell state
+        """Find minimum and maximum of cell state and neighbor cell states
+        
+        Args:
+            sol:
+                2D NumPy array of a solution profile (e.g. SolutionPhys.sol_prim),
+                where the first axis are the solution variables and the second axis are the spatial locations.
+
+        Returns:
+            NumPy arrays of the neighbor minimums and neighbor maximums, both of the same shape as sol.
         """
 
         # max and min of cell and neighbors

--- a/perform/limiter/venkat_limiter.py
+++ b/perform/limiter/venkat_limiter.py
@@ -5,9 +5,10 @@ from perform.limiter.limiter import Limiter
 
 
 class VenkatLimiter(Limiter):
-    """
-    Venkatakrishnan limiter
-    Differentiable, but limits in uniform regions
+    """Barth-Jespersen limiter.
+
+    This implements the limiter of Venkatakrishnan (1993) in one dimension.
+    The limiting function is differentiable, but limits in uniform regions.
     """
 
     def __init__(self):
@@ -15,8 +16,14 @@ class VenkatLimiter(Limiter):
         super().__init__()
 
     def calc_limiter(self, sol_domain, grad):
-        """
-        Compute multiplicative limiter
+        """Compute multiplicative limiter.
+
+        Args:
+            sol_domain: SolutionDomain with which this Limiter is associated.
+            grad: NumPy array of the un-limited gradient directly computed from finite difference stencil.
+
+        Returns:
+            NumPy array of the multiplicative gradient limiter profile.
         """
 
         sol_prim = sol_domain.sol_prim_full[:, sol_domain.grad_idxs]
@@ -43,27 +50,20 @@ class VenkatLimiter(Limiter):
         cond2_left = (sol_prim_left - sol_prim) < 0
         cond2_right = (sol_prim_right - sol_prim) < 0
 
-        # (y^2 + 2y) / (y^2 + y + 2)
-        def venkat_function(maxVals, cell_vals, face_vals):
-            frac = (maxVals - cell_vals) / (face_vals - cell_vals)
-            frac_sq = np.square(frac)
-            venk_vals = (frac_sq + 2.0 * frac) / (frac_sq + frac + 2.0)
-            return venk_vals
-
         # apply smooth Venkatakrishnan function
-        phi_left[cond1_left] = venkat_function(
+        phi_left[cond1_left] = self.venkat_function(
             sol_prim_max[cond1_left], sol_prim[cond1_left], sol_prim_left[cond1_left]
         )
 
-        phi_right[cond1_right] = venkat_function(
+        phi_right[cond1_right] = self.venkat_function(
             sol_prim_max[cond1_right], sol_prim[cond1_right], sol_prim_right[cond1_right]
         )
 
-        phi_left[cond2_left] = venkat_function(
+        phi_left[cond2_left] = self.venkat_function(
             sol_prim_min[cond2_left], sol_prim[cond2_left], sol_prim_left[cond2_left]
         )
 
-        phi_right[cond2_right] = venkat_function(
+        phi_right[cond2_right] = self.venkat_function(
             sol_prim_min[cond2_right], sol_prim[cond2_right], sol_prim_right[cond2_right]
         )
 
@@ -71,3 +71,21 @@ class VenkatLimiter(Limiter):
         phi = np.minimum(phi_left, phi_right)
 
         return phi
+
+    
+    def venkat_function(self, maxmin_vals, cell_vals, face_vals):
+        """Venkatakrishnan limiting function.
+
+        Args:
+            maxmin_vals:
+                NumPy array of neighbor maximum/minimum values, depending on portion of limiter being computed.
+            cell_vals: NumPy array of cell-centered solution profile.
+            face_vals: NumPy array of left or right face reconstruction solution profile.
+
+        Returns:
+            NumPy array of Venkatakrishnan multiplicative gradient limiter values.
+        """
+        frac = (maxmin_vals - cell_vals) / (face_vals - cell_vals)
+        frac_sq = np.square(frac)
+        venk_vals = (frac_sq + 2.0 * frac) / (frac_sq + frac + 2.0)
+        return venk_vals

--- a/perform/limiter/venkat_limiter.py
+++ b/perform/limiter/venkat_limiter.py
@@ -72,7 +72,6 @@ class VenkatLimiter(Limiter):
 
         return phi
 
-    
     def venkat_function(self, maxmin_vals, cell_vals, face_vals):
         """Venkatakrishnan limiting function.
 

--- a/perform/mesh.py
+++ b/perform/mesh.py
@@ -24,7 +24,7 @@ class Mesh:
     """
 
     def __init__(self, mesh_dict):
-       
+
         self.x_left = float(mesh_dict["x_left"])
         self.x_right = float(mesh_dict["x_right"])
         self.num_cells = int(mesh_dict["num_cells"])

--- a/perform/mesh.py
+++ b/perform/mesh.py
@@ -2,18 +2,33 @@ import numpy as np
 
 from perform.constants import REAL_TYPE
 
-# TODO: uniform, non-uniform meshes, grad operators and face reconstruction
-
 
 class Mesh:
+    """Class for defining computational mesh.
+
+    Currently, this directly implements a uniform mesh.
+    If, in the future, non-uniform and/or adaptive meshes are implemented, this should serve
+    as the base class for those more specific child classes.
+
+    Args:
+        mesh_dict:
+
+    Attributes:
+        x_left: Coordinate of left-most finite volume face, indicating the inlet boundary face.
+        x_right: Coordinate of right-most finite volume face, indicating the outlet boundary face.
+        num_cells: Number of finite volume cells, not including boundary ghost cells.
+        num_faces: Number of finite volume faces, including boundary faces.
+        x_face: NumPy array of coordinates of finite volume cell faces.
+        x_cell: NumPy array of coordinates of finite volume cell centers.
+        dx: Fixed finite "volume" cell length, in meters.
+    """
+
     def __init__(self, mesh_dict):
+       
         self.x_left = float(mesh_dict["x_left"])
         self.x_right = float(mesh_dict["x_right"])
         self.num_cells = int(mesh_dict["num_cells"])
         self.num_faces = self.num_cells + 1
         self.x_face = np.linspace(self.x_left, self.x_right, self.num_cells + 1, dtype=REAL_TYPE)
         self.x_cell = (self.x_face[1:] + self.x_face[:-1]) / 2.0
-
-        # TODO: Should be an array for non-uniform mesh
-        # TODO: Need distances between cell-centers and faces for visc flux
         self.dx = self.x_face[1] - self.x_face[0]

--- a/perform/misc_funcs.py
+++ b/perform/misc_funcs.py
@@ -1,25 +1,19 @@
+"""Miscellaneous functions that do not have a clear place in other modules."""
+
 import os
 import struct
 
 
 def write_to_file(fid, array, order="F"):
-    """
-    Write NumPy arrays to binary file using struct
+    """Write NumPy arrays to binary file using struct.
 
-    Inputs
-    ------
-    fid : file object
-        File opened with open(), in mode 'wb'
-    array : ndarray
-        Array to be written to fid
-    order (optional) : 'C' or 'F'
-        Order in which array will be flattened for output
-        'C' is row-major, 'F' is column-major
+    I used to use this for comparisons against GEMS, but is not
+    terribly useful otherwise. Kept here just in case.
 
-    Outputs
-    -------
-    None
-
+    Args:
+        fid: File opened with open(), in mode 'wb'.
+        array: Array to be written to fid.
+        order: "C" or "F", order in which array will be flattened for output. "C" is row-major, "F" is column-major.
     """
 
     if array.ndim > 1:
@@ -40,6 +34,17 @@ def write_to_file(fid, array, order="F"):
 
 
 def mkdir_shallow(base_dir, new_dir_name):
+    """Makes new directory, if it does not already exist.
+
+    Just a helper function for handling path joining.
+
+    Args:
+        base_dir: Path to directory in which new directory is to be made.
+        new_dir_name: Name of new directory to be created in base_dir.
+
+    Returns:
+        Path to new directory.
+    """
 
     new_dir = os.path.join(base_dir, new_dir_name)
     if not os.path.isdir(new_dir):

--- a/perform/reaction_model/finite_rate_irrev_reaction.py
+++ b/perform/reaction_model/finite_rate_irrev_reaction.py
@@ -11,21 +11,21 @@ class FiniteRateIrrevReaction(ReactionModel):
     irreversible reactions (i.e. only forwards)
     """
 
-    def __init__(self, gas, gas_dict):
+    def __init__(self, gas, chem_dict):
 
         super().__init__()
 
-        self.num_reactions = catch_input(gas_dict, "num_reactions", 0)
+        self.num_reactions = catch_input(chem_dict, "num_reactions", 0)
         assert self.num_reactions > 0, "Must have num_reactions > 0 if requesting a reaction model"
 
         # Arrhenius factors
-        self.nu = np.asarray(catch_list(gas_dict, "nu", [[-999.9]], len_highest=self.num_reactions), dtype=REAL_TYPE)
+        self.nu = np.asarray(catch_list(chem_dict, "nu", [[-999.9]], len_highest=self.num_reactions), dtype=REAL_TYPE)
         self.nu_arr = np.asarray(
-            catch_list(gas_dict, "nu_arr", [[-999.9]], len_highest=self.num_reactions), dtype=REAL_TYPE
+            catch_list(chem_dict, "nu_arr", [[-999.9]], len_highest=self.num_reactions), dtype=REAL_TYPE
         )
-        self.pre_exp_fact = np.asarray(catch_list(gas_dict, "pre_exp_fact", [-1.0]), dtype=REAL_TYPE)
-        self.temp_exp = np.asarray(catch_list(gas_dict, "temp_exp", [-1.0]), dtype=REAL_TYPE)
-        self.act_energy = np.asarray(catch_list(gas_dict, "act_energy", [-1.0]), dtype=REAL_TYPE)
+        self.pre_exp_fact = np.asarray(catch_list(chem_dict, "pre_exp_fact", [-1.0]), dtype=REAL_TYPE)
+        self.temp_exp = np.asarray(catch_list(chem_dict, "temp_exp", [-1.0]), dtype=REAL_TYPE)
+        self.act_energy = np.asarray(catch_list(chem_dict, "act_energy", [-1.0]), dtype=REAL_TYPE)
 
         assert self.nu.shape == (self.num_reactions, gas.num_species_full)
         assert self.nu_arr.shape == (self.num_reactions, gas.num_species_full)

--- a/perform/reaction_model/finite_rate_irrev_reaction.py
+++ b/perform/reaction_model/finite_rate_irrev_reaction.py
@@ -6,9 +6,30 @@ from perform.reaction_model.reaction_model import ReactionModel
 
 
 class FiniteRateIrrevReaction(ReactionModel):
-    """
-    Finite rate Arrhenius reaction model assuming
-    irreversible reactions (i.e. only forwards)
+    """Finite rate Arrhenius reaction model assuming irreversible reactions.
+
+    This reaction model only computes a forward reaction rate from the Arrhenius model.
+
+    Args:
+        gas: GasModel associated with the SolutionDomain with which this ReactionModel is associated.
+        chem_dict: Dictionary of input parameters read from chemistry file.
+
+    Attributes:
+        num_reactions: Number of reactions to model.
+        nu:
+            2D NumPy array of stoichiometric coefficients, where the first axis corresponds to each reaction
+            and the second axis corresponds to each of the num_species_full chemical species.
+        nu_arr:
+            2D NumPy array of Arrhenius rate molar concentration exponential terms,
+            where the first axis corresponds to each reaction, and the second axis corresponds
+            to each of the num_species_full chemical species.
+        pre_exp_fact: 1D NumPy array of Arrhenius rate pre-exponential factors for each reaction.
+        temp_exp: 1D NumPy array of Arrhenius rate temperature exponential factors for each reaction.
+        act_energy: 1D NumPy array of Arrhenius rate activation energy for each reaction.
+        mol_weight_nu:
+            2D NumPy array of stoichiometric coefficients multiplied by molecular weight, where the first axis
+            corresponds to each reaction and the second axis corresponds to each of the num_species_full
+            chemical species. Precomputed for cost savings.
     """
 
     def __init__(self, gas, chem_dict):
@@ -38,11 +59,21 @@ class FiniteRateIrrevReaction(ReactionModel):
         self.mol_weight_nu = gas.mol_weights[None, :] * self.nu
 
     def calc_source(self, sol, dt, samp_idxs=np.s_[:]):
-        """
-        Compute chemical source term
+        """Compute reaction source term.
+
+        Args:
+            sol: SolutionPhys for which the source term is to be calculated.
+            dt:
+                Physical time step, used for thresholding rate of progress to avoid
+                consuming more mass than exists at a point.
+
+        Returns:
+            source: NumPy array of source term profiles for the num_species species transport governing equations.
+            wf: NumPy array of rate-of-progress profiles for each reaction.
         """
 
         # TODO: for larger mechanisms, definitely a lot of wasted flops where nu = 0.0
+        # TODO: wf should be stored in sol here, not returned, as this isn't general to every reaction model.
 
         gas = sol.gas_model
 
@@ -50,14 +81,14 @@ class FiniteRateIrrevReaction(ReactionModel):
         rho = sol.sol_cons[[0], samp_idxs]
         rho_mass_frac = rho * sol.mass_fracs_full[:, samp_idxs]
 
-        # rate-of-progress
+        # Rate-of-progress
         pre_exp = self.pre_exp_fact[:, None] * np.power(temp[None, :], self.temp_exp[:, None])
         wf = pre_exp * np.exp((-self.act_energy[:, None] / R_UNIV) / temp[None, :])
         wf *= np.product(
             np.power((rho_mass_frac / gas.mol_weights[:, None])[None, :, :], self.nu_arr[:, :, None]), axis=1
         )
 
-        # threshold
+        # Threshold
         wf = np.minimum(wf, rho_mass_frac[gas.mass_frac_slice, :] / dt)
 
         source = -np.sum(self.mol_weight_nu[:, gas.mass_frac_slice, None] * wf[:, None, :], axis=0)
@@ -65,13 +96,25 @@ class FiniteRateIrrevReaction(ReactionModel):
         return source, wf
 
     def calc_jacob_prim(self, sol_int, samp_idxs=np.s_[:]):
-        """
-        Compute source term Jacobian
+        """Compute and assemble source Jacobian with respect to the primitive variables.
+
+        Calculates source Jacobian with respect to each finite volume cell's own state. This ultimately
+        contributes to the center block diagonal of the residual Jacobian.
+
+        Args:
+            sol_int: SolutionInterior of the SolutionDomain with which this ReactionModel is associated.
+            samp_idxs:
+                Either a NumPy slice or NumPy array for selecting sampled cells to compute the Jacobian at.
+                Used for hyper-reduction of projection-based reduced-order models.
+
+        Returns:
+            jacob: center block diagonal of source Jacobian, representing the gradient of a given cell's
+            viscous flux contribution with respect to its own primitive state.
         """
 
         gas = sol_int.gas_model
 
-        # initialize Jacobian
+        # Initialize Jacobian
         if type(samp_idxs) is slice:
             num_cells = sol_int.num_cells
         else:
@@ -83,8 +126,8 @@ class FiniteRateIrrevReaction(ReactionModel):
         temp = sol_int.sol_prim[2, samp_idxs]
         mass_fracs = sol_int.sol_prim[3:, samp_idxs]
 
-        # assumes density derivatives have been precomputed
-        # this is done in calc_res_jacob()
+        # Assumes density derivatives have been precomputed
+        # This is done in calc_res_jacob()
         d_rho_d_press = sol_int.d_rho_d_press[samp_idxs]
         d_rho_d_temp = sol_int.d_rho_d_temp[samp_idxs]
         d_rho_d_mass_frac = sol_int.d_rho_d_mass_frac[:, samp_idxs]
@@ -106,7 +149,7 @@ class FiniteRateIrrevReaction(ReactionModel):
                 wf[:, pos_mf_idxs] * self.nu_arr[:, spec_idx, None] / mass_fracs[None, spec_idx, pos_mf_idxs]
             )
 
-        # compute Jacobian
+        # Compute Jacobian
         jacob[3:, 0, :] = -np.sum(self.mol_weight_nu[:, gas.mass_frac_slice, None] * d_wf_d_press[:, None, :], axis=0)
         jacob[3:, 2, :] = -np.sum(self.mol_weight_nu[:, gas.mass_frac_slice, None] * d_wf_d_temp[:, None, :], axis=0)
 

--- a/perform/reaction_model/finite_rate_irrev_reaction.py
+++ b/perform/reaction_model/finite_rate_irrev_reaction.py
@@ -122,7 +122,6 @@ class FiniteRateIrrevReaction(ReactionModel):
         jacob = np.zeros((gas.num_eqs, gas.num_eqs, num_cells), dtype=REAL_TYPE)
 
         rho = sol_int.sol_cons[0, samp_idxs]
-        press = sol_int.sol_prim[0, samp_idxs]
         temp = sol_int.sol_prim[2, samp_idxs]
         mass_fracs = sol_int.sol_prim[3:, samp_idxs]
 

--- a/perform/reaction_model/reaction_model.py
+++ b/perform/reaction_model/reaction_model.py
@@ -1,4 +1,14 @@
 class ReactionModel:
+    """Base class for all reaction models.
+
+    All child classes must implement the following member functions:
+    
+    * calc_source()
+    * calc_jacob_prim()
+
+    Refer to finite_rate_irrev_reaction.py for examples.
+    """
+
     def __init__(self):
 
         pass

--- a/perform/reaction_model/reaction_model.py
+++ b/perform/reaction_model/reaction_model.py
@@ -2,7 +2,7 @@ class ReactionModel:
     """Base class for all reaction models.
 
     All child classes must implement the following member functions:
-    
+
     * calc_source()
     * calc_jacob_prim()
 

--- a/perform/rom/__init__.py
+++ b/perform/rom/__init__.py
@@ -24,10 +24,7 @@ except ImportError:
 
 
 def get_rom_model(model_idx, rom_domain, sol_domain):
-    """
-    Helper function to retrieve various models
-    Helps keep the clutter our of rom_domain
-    """
+    """Helper function to retrieve ROM models"""
 
     # linear subspace methods
     if rom_domain.rom_method == "linear_galerkin_proj":

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_proj_rom.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_proj_rom.py
@@ -7,11 +7,11 @@ from perform.input_funcs import catch_input
 
 class AutoencoderProjROM(ProjectionROM):
     """Base class for all non-linear manifold projection-based ROMs using autoencoders.
-    
+
     Inherits from ProjectionROM. Assumes that solution decoding is computed by
 
     sol = cent_prof + norm_sub_prof + norm_fac_prof * decoder(code)
-    
+
     Child classes must implement the following member functions with
     library-specific (e.g. TensorFlow-Keras, PyTorch) implementations:
     * load_model_obj()

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_proj_rom.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_proj_rom.py
@@ -6,11 +6,44 @@ from perform.input_funcs import catch_input
 
 
 class AutoencoderProjROM(ProjectionROM):
-    """
-    Base class for any non-linear manifold ROM using autoencoders
+    """Base class for all non-linear manifold projection-based ROMs using autoencoders.
+    
+    Inherits from ProjectionROM. Assumes that solution decoding is computed by
 
-    Child classes simply supply library-dependent functions
-    (e.g. for TensorFlow, PyTorch)
+    sol = cent_prof + norm_sub_prof + norm_fac_prof * decoder(code)
+    
+    Child classes must implement the following member functions with
+    library-specific (e.g. TensorFlow-Keras, PyTorch) implementations:
+    * load_model_obj()
+    * check_model()
+    * apply_decoder()
+    * apply_encoder()
+    * calc_analytical_model_jacobian()
+    * calc_numerical_model_jacobian()
+    * calc_model_jacobian()
+    Check autoencoder_tfkeras.py for further details on these methods.
+
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+    Attributes:
+        decoder:
+            Decoder model object (e.g. tf.keras.Model) which maps from the low-dimensional state
+            to the full-dimensional state.
+        decoder_io_dtypes: List containing the data type of the decoder input and output.
+        encoder_jacob:
+            Boolean flag indicating whether the method should use an encoder Jacobian approximation, if applicable.
+        encoder:
+            Encoder model object (e.g. tf.keras.Model) which maps from the full-dimensional state
+            to the low-dimensional state. Only required if initializing the simulation from a full-dimensional
+            initial conditions or the ROM method requires an encoder.
+        encoder_io_dtypes: List containing the data type of the encoder input and output.
+        numerical_jacob:
+            Boolean flag indicating whether the decoder/encoder Jacobian should be computed numerically.
+            If False (default), computes the Jacobian analytically using automatic differentiation.
+        fd_step: Finite-difference step size for computing the numerical decoder/encoder Jacobian, if requested.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -26,8 +59,7 @@ class AutoencoderProjROM(ProjectionROM):
         self.decoder_io_dtypes = self.check_model(decoder=True)
 
         # If required, load encoder
-        # Encoder is required for encoder Jacobian
-        # 	or initializing from projection of full ICs
+        # Encoder is required for encoder Jacobian or initializing from projection of full ICs
         self.encoder_jacob = catch_input(rom_dict, "encoder_jacob", False)
         self.encoder = None
         if self.encoder_jacob or (rom_domain.low_dim_init_files[model_idx] == ""):
@@ -43,15 +75,24 @@ class AutoencoderProjROM(ProjectionROM):
         self.numerical_jacob = catch_input(rom_dict, "numerical_jacob", False)
         self.fd_step = catch_input(rom_dict, "fd_step", FD_STEP_DEFAULT)
 
-    def encode_sol(self, solIn):
-        """
-        Compute encoding of full-dimensional state,
-        including centering and normalization
+    def encode_sol(self, sol_in):
+        """Compute full encoding of solution, including centering and normalization.
+
+        Centers and normalizes full-dimensional sol_in, and then maps to low-dimensional code.
+        Note that the apply_encoder is implemented within child classes, as these are specific to a specific library.
+
+        Args:
+            sol_in: Full-dimensional state to be encoded.
+
+        Returns:
+            Low-dimensional code NumPy array resulting from scaling and decoding.
         """
 
+        sol = sol_in.copy()
+
         if self.target_cons:
-            sol = self.standardize_data(
-                solIn,
+            sol = self.scale_profile(
+                sol,
                 normalize=True,
                 norm_fac_prof=self.norm_fac_prof_cons,
                 norm_sub_prof=self.norm_sub_prof_cons,
@@ -61,8 +102,8 @@ class AutoencoderProjROM(ProjectionROM):
             )
 
         else:
-            sol = self.standardize_data(
-                solIn,
+            sol = self.scale_profile(
+                sol,
                 normalize=True,
                 norm_fac_prof=self.norm_fac_prof_prim,
                 norm_sub_prof=self.norm_sub_prof_prim,
@@ -76,9 +117,14 @@ class AutoencoderProjROM(ProjectionROM):
         return code
 
     def init_from_sol(self, sol_domain):
-        """
-        Initialize full-order solution from projection of
-        loaded full-order initial conditions
+        """Initialize full-order solution from encoding and decoding of loaded full-order initial conditions.
+
+        Computes encoding and decoding of full-dimensional initial conditions and sets as
+        new initial condition solution profile. This is automatically used if a low-dimensional state
+        initial condition file is not provided.
+
+        Args:
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
         """
 
         sol_int = sol_domain.sol_int

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_galerkin_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_galerkin_proj_tfkeras.py
@@ -66,7 +66,7 @@ class AutoencoderGalerkinProjTFKeras(AutoencoderTFKeras):
             lhs: Left-hand side of low-dimensional linear solve.
             rhs: Right-hand side of low-dimensional linear solve.
         """
-        
+
         # TODO: this is non-general and janky, only valid for BDF
 
         jacob = self.calc_model_jacobian(sol_domain)

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_galerkin_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_galerkin_proj_tfkeras.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorflow as tf
 from scipy.linalg import pinv
 
 from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoencoder_tfkeras import AutoencoderTFKeras
@@ -8,10 +7,10 @@ from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoenc
 class AutoencoderGalerkinProjTFKeras(AutoencoderTFKeras):
     """Class for projection-based ROM with a TF-Keras non-linear manifold decoder and Galerkin projection.
 
-    Inherits from AutoencoderTFKeras. 
-    
+    Inherits from AutoencoderTFKeras.
+
     Decoder is assumed to map to the conservative variables. Allows implicit and explicit time integration.
-    
+
     Args:
         model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
         rom_domain: RomDomain within which this RomModel is contained.

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_galerkin_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_galerkin_proj_tfkeras.py
@@ -6,8 +6,16 @@ from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoenc
 
 
 class AutoencoderGalerkinProjTFKeras(AutoencoderTFKeras):
-    """
-    Class for computing non-linear Galerkin ROMs via a TensorFlow autoencoder
+    """Class for projection-based ROM with a TF-Keras non-linear manifold decoder and Galerkin projection.
+
+    Inherits from AutoencoderTFKeras. 
+    
+    Decoder is assumed to map to the conservative variables. Allows implicit and explicit time integration.
+    
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -18,10 +26,15 @@ class AutoencoderGalerkinProjTFKeras(AutoencoderTFKeras):
         super().__init__(model_idx, rom_domain, sol_domain)
 
     def calc_projector(self, sol_domain):
-        """
-        Compute rhs projection operator
-        Decoder projector is pseudo-inverse of decoder Jacobian
-        Encoder projector is just encoder Jacobian
+        """Compute RHS projection operator.
+
+        Called by ProjectionROM.calc_rhs_low_dim() to compute projection operator which is applied to RHS function
+        for explicit time integration.
+
+        Decoder projector is pseudo-inverse of decoder Jacobian, and encoder projector is simply encoder Jacobian.
+
+        Args:
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
         """
 
         jacob = self.calc_model_jacobian(sol_domain)
@@ -33,12 +46,28 @@ class AutoencoderGalerkinProjTFKeras(AutoencoderTFKeras):
             self.projector = pinv(jacob)
 
     def calc_d_code(self, res_jacob, res, sol_domain):
-        """
-        Compute change in low-dimensional state for
-        implicit scheme Newton iteration
+        """Compute change in low-dimensional state for implicit scheme Newton iteration.
 
-        TODO: this is non-general and janky, only valid for BDF
+        This function computes the iterative change in the low-dimensional state for a given Newton iteration
+        of an implicit time integration scheme. Please refer to Lee and Carlberg (2020) for details on the
+        formulation for Galerkin projection.
+
+        Args:
+            res_jacob:
+                scipy.sparse.csr_matrix containing full-dimensional residual Jacobian with respect to
+                the conservative variables.
+            res: NumPy array of fully-discrete residual, already negated for Newton iteration.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+        Returns:
+            d_code:
+                Solution of low-dimensional linear solve, representing the iterative change in
+                the low-dimensional state.
+            lhs: Left-hand side of low-dimensional linear solve.
+            rhs: Right-hand side of low-dimensional linear solve.
         """
+        
+        # TODO: this is non-general and janky, only valid for BDF
 
         jacob = self.calc_model_jacobian(sol_domain)
 

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_lspg_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_lspg_proj_tfkeras.py
@@ -1,5 +1,4 @@
 import numpy as np
-import tensorflow as tf
 
 from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoencoder_tfkeras import AutoencoderTFKeras
 
@@ -7,10 +6,10 @@ from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoenc
 class AutoencoderLSPGProjTFKeras(AutoencoderTFKeras):
     """Class for projection-based ROM with a TF-Keras non-linear manifold decoder and LSPG projection.
 
-    Inherits from AutoencoderTFKeras. 
-    
+    Inherits from AutoencoderTFKeras.
+
     Decoder is assumed to map to the conservative variables. Allows implicit time integration only.
-    
+
     Args:
         model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
         rom_domain: RomDomain within which this RomModel is contained.

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_lspg_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_lspg_proj_tfkeras.py
@@ -5,9 +5,16 @@ from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoenc
 
 
 class AutoencoderLSPGProjTFKeras(AutoencoderTFKeras):
-    """
-    Class for computing non-linear least-squares Petrov-Galerkin ROMs
-    via a TensorFlow autoencoder
+    """Class for projection-based ROM with a TF-Keras non-linear manifold decoder and LSPG projection.
+
+    Inherits from AutoencoderTFKeras. 
+    
+    Decoder is assumed to map to the conservative variables. Allows implicit time integration only.
+    
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -29,9 +36,25 @@ class AutoencoderLSPGProjTFKeras(AutoencoderTFKeras):
             )
 
     def calc_d_code(self, res_jacob, res, sol_domain):
-        """
-        Compute change in low-dimensional state for
-        implicit scheme Newton iteration
+        """Compute change in low-dimensional state for implicit scheme Newton iteration.
+
+        This function computes the iterative change in the low-dimensional state for a given Newton iteration
+        of an implicit time integration scheme. Please refer to Lee and Carlberg (2020) for details on the
+        formulation for LSPG projection.
+
+        Args:
+            res_jacob:
+                scipy.sparse.csr_matrix containing full-dimensional residual Jacobian with respect to
+                the conservative variables.
+            res: NumPy array of fully-discrete residual, already negated for Newton iteration.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+        Returns:
+            d_code:
+                Solution of low-dimensional linear solve, representing the iterative change in
+                the low-dimensional state.
+            lhs: Left-hand side of low-dimensional linear solve.
+            rhs: Right-hand side of low-dimensional linear solve.
         """
 
         # decoder Jacobian, scaled

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_splsvt_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_splsvt_proj_tfkeras.py
@@ -6,10 +6,10 @@ from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoenc
 class AutoencoderSPLSVTProjTFKeras(AutoencoderTFKeras):
     """Class for projection-based ROM with a TF-Keras non-linear manifold decoder and SP-LSVT projection.
 
-    Inherits from AutoencoderTFKeras. 
-    
+    Inherits from AutoencoderTFKeras.
+
     Decoder is assumed to map to the primitive variables. Allows implicit time integration only.
-    
+
     Args:
         model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
         rom_domain: RomDomain within which this RomModel is contained.

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_splsvt_proj_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_splsvt_proj_tfkeras.py
@@ -4,8 +4,16 @@ from perform.rom.projection_rom.autoencoder_proj_rom.autoencoder_tfkeras.autoenc
 
 
 class AutoencoderSPLSVTProjTFKeras(AutoencoderTFKeras):
-    """
-    Class for computing non-linear Galerkin ROMs via a TensorFlow autoencoder
+    """Class for projection-based ROM with a TF-Keras non-linear manifold decoder and SP-LSVT projection.
+
+    Inherits from AutoencoderTFKeras. 
+    
+    Decoder is assumed to map to the primitive variables. Allows implicit time integration only.
+    
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -27,9 +35,24 @@ class AutoencoderSPLSVTProjTFKeras(AutoencoderTFKeras):
             )
 
     def calc_d_code(self, res_jacob, res, sol_domain):
-        """
-        Compute change in low-dimensional state for
-        implicit scheme Newton iteration
+        """Compute change in low-dimensional state for implicit scheme Newton iteration.
+
+        This function computes the iterative change in the low-dimensional state for a given Newton iteration
+        of an implicit time integration scheme.
+
+        Args:
+            res_jacob:
+                scipy.sparse.csr_matrix containing full-dimensional residual Jacobian with respect to
+                the primitive variables.
+            res: NumPy array of fully-discrete residual, already negated for Newton iteration.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+        Returns:
+            d_code:
+                Solution of low-dimensional linear solve, representing the iterative change in
+                the low-dimensional state.
+            lhs: Left-hand side of low-dimensional linear solve.
+            rhs: Right-hand side of low-dimensional linear solve.
         """
 
         # decoder Jacobian, scaled

--- a/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_tfkeras.py
+++ b/perform/rom/projection_rom/autoencoder_proj_rom/autoencoder_tfkeras/autoencoder_tfkeras.py
@@ -14,7 +14,7 @@ class AutoencoderTFKeras(AutoencoderProjROM):
     """Base class for autoencoder projection-based ROMs using TensorFlow-Keras.
 
     Inherits from AutoencoderProjROM. Supplies library-specific functions noted in AutoencoderProjROM.
-    
+
     Child classes must implement a calc_projector() member function if it permits explicit time integration,
     and/or a calc_d_code() member function if it permits implicit time integration.
 
@@ -85,7 +85,7 @@ class AutoencoderTFKeras(AutoencoderProjROM):
         as determined by num_vars, num_cells, and latent_dim.
 
         Args:
-            decoder: 
+            decoder:
                 Boolean indicating whether to return the shape of this RomModel's decoder (decoder=True)
                 or encoder (decoder=False).
 
@@ -138,7 +138,7 @@ class AutoencoderTFKeras(AutoencoderProjROM):
 
     def apply_decoder(self, code):
         """Compute raw decoding of code.
-        
+
         Only computes decoder(code), does not compute any denormalization or decentering.
 
         Args:
@@ -153,7 +153,7 @@ class AutoencoderTFKeras(AutoencoderProjROM):
 
     def apply_encoder(self, sol):
         """Compute raw encoding of full-dimensional state.
-        
+
         Only computes encoder(sol), does not compute any centering or normalization.
 
         Args:

--- a/perform/rom/projection_rom/linear_proj_rom/linear_galerkin_proj.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_galerkin_proj.py
@@ -4,10 +4,20 @@ from perform.rom.projection_rom.linear_proj_rom.linear_proj_rom import LinearPro
 
 
 class LinearGalerkinProj(LinearProjROM):
-    """
-    Class for linear decoder and Galerkin projection
+    """Class for projection-based ROM with linear decoder and Galerkin projection.
 
-    Trial basis is assumed to represent the conserved variables
+    Inherits from LinearProjROM. 
+    
+    Trial basis is assumed to represent the conservative variables. Allows implicit and explicit time integration.
+    
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+    Attributes:
+        trial_basis_scaled: 2D NumPy array of trial basis scaled by norm_fac_prof_cons. Precomputed for cost savings.
+        hyper_reduc_operator: 2D NumPy array of gappy POD projection operator. Precomputed for cost savings.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -30,8 +40,13 @@ class LinearGalerkinProj(LinearProjROM):
             )
 
     def calc_projector(self, sol_domain):
-        """
-        Compute RHS projection operator
+        """Compute RHS projection operator.
+
+        Called by ProjectionROM.calc_rhs_low_dim() to compute projection operator which is applied to RHS function
+        for explicit time integration.
+
+        Args:
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
         """
 
         if self.hyper_reduc:
@@ -40,8 +55,26 @@ class LinearGalerkinProj(LinearProjROM):
             self.projector = self.trial_basis.T
 
     def calc_d_code(self, res_jacob, res, sol_domain):
-        """
-        Compute change in low-dimensional state for implicit scheme Newton iteration
+        """Compute change in low-dimensional state for implicit scheme Newton iteration.
+
+        This function computes the iterative change in the low-dimensional state for a given Newton iteration
+        of an implicit time integration scheme. For Galerkin projection, this is given by
+
+        V^T * P^-1 * res_jacob * P * V * d_code = V^T * P^-1 * res
+
+        Args:
+            res_jacob:
+                scipy.sparse.csr_matrix containing full-dimensional residual Jacobian with respect to
+                the conservative variables.
+            res: NumPy array of fully-discrete residual, already negated for Newton iteration.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+        Returns:
+            d_code:
+                Solution of low-dimensional linear solve, representing the iterative change in
+                the low-dimensional state.
+            lhs: Left-hand side of low-dimensional linear solve.
+            rhs: Right-hand side of low-dimensional linear solve.
         """
 
         lhs = (res_jacob @ self.trial_basis_scaled) / self.norm_fac_prof_cons.ravel(order="C")[
@@ -49,6 +82,7 @@ class LinearGalerkinProj(LinearProjROM):
         ]
         res_scaled = (res / self.norm_fac_prof_cons[:, sol_domain.direct_samp_idxs]).ravel(order="C")
 
+        # Project LHS and RHS onto low-dimensional space, solve linear system
         if self.hyper_reduc:
             lhs = self.hyper_reduc_operator @ lhs
             rhs = self.hyper_reduc_operator @ res_scaled

--- a/perform/rom/projection_rom/linear_proj_rom/linear_galerkin_proj.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_galerkin_proj.py
@@ -6,10 +6,10 @@ from perform.rom.projection_rom.linear_proj_rom.linear_proj_rom import LinearPro
 class LinearGalerkinProj(LinearProjROM):
     """Class for projection-based ROM with linear decoder and Galerkin projection.
 
-    Inherits from LinearProjROM. 
-    
+    Inherits from LinearProjROM.
+
     Trial basis is assumed to represent the conservative variables. Allows implicit and explicit time integration.
-    
+
     Args:
         model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
         rom_domain: RomDomain within which this RomModel is contained.

--- a/perform/rom/projection_rom/linear_proj_rom/linear_lspg_proj.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_lspg_proj.py
@@ -5,8 +5,8 @@ from perform.rom.projection_rom.linear_proj_rom.linear_proj_rom import LinearPro
 
 class LinearLSPGProj(LinearProjROM):
     """Class for projection-based ROM with linear decoder and least-squares Petrov-Galerkin projection.
-    
-    Inherits from LinearProjROM. 
+
+    Inherits from LinearProjROM.
 
     Trial basis is assumed to represent the conservative variables. Allows implicit time integration only.
 

--- a/perform/rom/projection_rom/linear_proj_rom/linear_lspg_proj.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_lspg_proj.py
@@ -4,15 +4,25 @@ from perform.rom.projection_rom.linear_proj_rom.linear_proj_rom import LinearPro
 
 
 class LinearLSPGProj(LinearProjROM):
-    """
-    Class for linear decoder and least-squares Petrov-Galerkin projection
-    Trial basis is assumed to represent the conserved variables
+    """Class for projection-based ROM with linear decoder and least-squares Petrov-Galerkin projection.
+    
+    Inherits from LinearProjROM. 
+
+    Trial basis is assumed to represent the conservative variables. Allows implicit time integration only.
+
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+    Attributes:
+        trial_basis_scaled: 2D NumPy array of trial basis scaled by norm_fac_prof_cons. Precomputed for cost savings.
+        hyper_reduc_operator: 2D NumPy array of gappy POD projection operator. Precomputed for cost savings.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
 
-        # I'm not going to code LSPG with explicit time integrator,
-        # it's a pointless exercise
+        # I'm not going to code LSPG with an explicit time integrator, it's a pointless exercise.
         if rom_domain.time_integrator.time_type == "explicit":
             raise ValueError(
                 "LSPG with an explicit time integrator deteriorates to Galerkin, please use"
@@ -26,16 +36,37 @@ class LinearLSPGProj(LinearProjROM):
 
         self.trial_basis_scaled = self.trial_basis * self.norm_fac_prof_cons.ravel(order="C")[:, None]
 
-        # procompute hyper-reduction projector, [S^T * U]^+
+        # Precompute hyper-reduction projector, [S^T * U]^+
         # TODO: may want to have an option to compute U * [S^T * U]^+
         #   The matrix can be big, but it's necessary for conservative LSPG, different least-square problem
         if self.hyper_reduc:
             self.hyper_reduc_operator = np.linalg.pinv(self.hyper_reduc_basis[self.direct_samp_idxs_flat, :])
 
     def calc_d_code(self, res_jacob, res, sol_domain):
-        """
-        Compute change in low-dimensional state for
-        implicit scheme Newton iteration
+        """Compute change in low-dimensional state for implicit scheme Newton iteration.
+
+        This function computes the iterative change in the low-dimensional state for a given Newton iteration
+        of an implicit time integration scheme. For least-squares Petrov-Galerkin projection, this is given by
+
+        W^T * W * d_code = W^T * res
+
+        Where
+
+        W = P^-1 * res_jacob * P * V
+
+        Args:
+            res_jacob:
+                scipy.sparse.csr_matrix containing full-dimensional residual Jacobian with respect to the
+                conservative variables.
+            res: NumPy array of fully-discrete residual, already negated for Newton iteration.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+        Returns:
+            d_code:
+                Solution of low-dimensional linear solve, representing the iterative change in
+                the low-dimensional state.
+            lhs: Left-hand side of low-dimensional linear solve.
+            rhs: Right-hand side of low-dimensional linear solve.
         """
 
         # Compute test basis
@@ -45,7 +76,7 @@ class LinearLSPGProj(LinearProjROM):
         if self.hyper_reduc:
             test_basis = self.hyper_reduc_operator @ test_basis
 
-        # lhs and rhs of Newton iteration
+        # LHS and RHS of Newton iteration
         lhs = test_basis.T @ test_basis
 
         res_scaled = (res / self.norm_fac_prof_cons[:, sol_domain.direct_samp_idxs]).ravel(order="C")

--- a/perform/rom/projection_rom/linear_proj_rom/linear_proj_rom.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_proj_rom.py
@@ -141,7 +141,7 @@ class LinearProjROM(ProjectionROM):
 
     def apply_decoder(self, code):
         """Compute raw decoding of code.
-        
+
         Only computes trial_basis @ code, does not compute any denormalization or decentering.
 
         Args:

--- a/perform/rom/projection_rom/linear_proj_rom/linear_proj_rom.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_proj_rom.py
@@ -4,9 +4,31 @@ from perform.rom.projection_rom.projection_rom import ProjectionROM
 
 
 class LinearProjROM(ProjectionROM):
-    """
-    Base class for all projection-based ROMs
-    which use a linear basis representation
+    """Base class for all linear subspace projection-based ROMs.
+
+    Inherits from ProjectionROM. Assumes that solution decoding is computed by
+
+    sol = cent_prof + norm_sub_prof + norm_fac_prof * (trial_basis @ code)
+
+    Child classes must implement a calc_projector() member function if it permits explicit time integration,
+    and/or a calc_d_code() member function if it permits implicit time integration.
+
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+    Attributes:
+        trial_basis:
+            2D NumPy array containing latent_dim trial basis modes. Modes are flattened in C order,
+            i.e. iterating first over cells, then over variables.
+        hyper_reduc_dim: Number of modes to retain in hyper_reduc_basis.
+        hyper_reduc_basis:
+            2D NumPy array containing hyper_reduc_dim hyper-reduction basis modes. Modes are flattened in C order,
+            i.e. iterating first over cells, then over variables.
+        direct_samp_idxs_flat:
+            NumPy array of slicing indices for slicing directly-sampled cells from
+            solution-related vectors flattened in C order.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -79,13 +101,18 @@ class LinearProjROM(ProjectionROM):
             self.direct_samp_idxs_flat = np.s_[:]
 
     def init_from_sol(self, sol_domain):
-        """
-        Initialize full-order solution from projection of
-        loaded full-order initial conditions
+        """Initialize full-order solution from projection of loaded full-order initial conditions.
+
+        Computes L2 projection of the initial conditions onto the trial space, i.e. V * V^T * q_r, and sets as
+        full-dimensional initial condition solution profile. This is automatically used if a low-dimensional state
+        initial condition file is not provided.
+
+        Args:
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
         """
 
         if self.target_cons:
-            sol = self.standardize_data(
+            sol = self.scale_profile(
                 sol_domain.sol_int.sol_cons[self.var_idxs, :],
                 normalize=True,
                 norm_fac_prof=self.norm_fac_prof_cons,
@@ -99,7 +126,7 @@ class LinearProjROM(ProjectionROM):
             sol_domain.sol_int.sol_cons[self.var_idxs, :] = self.decode_sol(self.code)
 
         else:
-            sol = self.standardize_data(
+            sol = self.scale_profile(
                 sol_domain.sol_int.sol_prim[self.var_idxs, :],
                 normalize=True,
                 norm_fac_prof=self.norm_fac_prof_prim,
@@ -113,8 +140,12 @@ class LinearProjROM(ProjectionROM):
             sol_domain.sol_int.sol_prim[self.var_idxs, :] = self.decode_sol(self.code)
 
     def apply_decoder(self, code):
-        """
-        Compute raw decoding of code, without de-normalizing or de-centering
+        """Compute raw decoding of code.
+        
+        Only computes trial_basis @ code, does not compute any denormalization or decentering.
+
+        Args:
+            code: NumPy array of low-dimensional state, of dimension latent_dim.
         """
 
         sol = self.trial_basis @ code

--- a/perform/rom/projection_rom/linear_proj_rom/linear_splsvt_proj.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_splsvt_proj.py
@@ -5,8 +5,8 @@ from perform.rom.projection_rom.linear_proj_rom.linear_proj_rom import LinearPro
 
 class LinearSPLSVTProj(LinearProjROM):
     """Class for projection-based ROM with linear decoder and SP-LSVT projection.
-    
-    Inherits from LinearProjROM. 
+
+    Inherits from LinearProjROM.
 
     Trial basis is assumed to represent the primitive variables. Allows implicit time integration only.
 

--- a/perform/rom/projection_rom/linear_proj_rom/linear_splsvt_proj.py
+++ b/perform/rom/projection_rom/linear_proj_rom/linear_splsvt_proj.py
@@ -4,9 +4,20 @@ from perform.rom.projection_rom.linear_proj_rom.linear_proj_rom import LinearPro
 
 
 class LinearSPLSVTProj(LinearProjROM):
-    """
-    Class for linear decoder and SP-LSVT formulation
-    Trial basis is assumed to represent the conserved variables
+    """Class for projection-based ROM with linear decoder and SP-LSVT projection.
+    
+    Inherits from LinearProjROM. 
+
+    Trial basis is assumed to represent the primitive variables. Allows implicit time integration only.
+
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+    Attributes:
+        trial_basis_scaled: 2D NumPy array of trial basis scaled by norm_fac_prof_prim. Precomputed for cost savings.
+        hyper_reduc_operator: 2D NumPy array of gappy POD projection operator. Precomputed for cost savings.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -29,8 +40,30 @@ class LinearSPLSVTProj(LinearProjROM):
             self.hyper_reduc_operator = np.linalg.pinv(self.hyper_reduc_basis[self.direct_samp_idxs_flat, :])
 
     def calc_d_code(self, res_jacob, res, sol_domain):
-        """
-        Compute change in low-dimensional state for implicit scheme Newton iteration
+        """Compute change in low-dimensional state for implicit scheme Newton iteration.
+
+        This function computes the iterative change in the low-dimensional state for a given Newton iteration
+        of an implicit time integration scheme. For SP-LSVT projection, this is given by
+
+        W^T * W * d_code = W^T * res
+
+        Where
+
+        W = P^-1 * res_jacob * H * V_p
+
+        Args:
+            res_jacob:
+                scipy.sparse.csr_matrix containing full-dimensional residual Jacobian with respect to the
+                primitive variables.
+            res: NumPy array of fully-discrete residual, already negated for Newton iteration.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
+
+        Returns:
+            d_code:
+                Solution of low-dimensional linear solve, representing the iterative change in
+                the low-dimensional state.
+            lhs: Left-hand side of low-dimensional linear solve.
+            rhs: Right-hand side of low-dimensional linear solve.
         """
 
         # compute test basis

--- a/perform/rom/projection_rom/projection_rom.py
+++ b/perform/rom/projection_rom/projection_rom.py
@@ -5,24 +5,36 @@ from perform.constants import REAL_TYPE
 
 
 class ProjectionROM(RomModel):
-    """
-    Base class for projection-based reduced-order model
+    """Base class for projection-based reduced-order models.
 
-    This model makes no assumption on the form of the decoder,
-    but assumes a linear projection onto the low-dimensional space
+    Inherits from RomModel. This class makes no assumption on the form of the decoder,
+    but assumes a linear projection onto the low-dimensional space. 
+
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
     """
 
     def __init__(self, modelIdx, rom_domain, sol_domain):
 
+        self.hyper_reduc = rom_domain.hyper_reduc
+
         super().__init__(modelIdx, rom_domain, sol_domain)
 
     def project_to_low_dim(self, projector, full_dim_arr, transpose=False):
-        """
-        Project given full-dimensional vector onto low-dimensional space via given projector
+        """Project given full-dimensional vector onto low-dimensional space via given projector.
 
-        Assumed that full_dim_arr is either 1D array or is in [numVars, numCells] order
+        Assumes that full_dim_arr is either 1D array or is in [num_vars, num_cells] order.
+        Further assumes that projector is already in [latent_dim, num_vars x num_cells] order.
 
-        Assumed that projector is already in [numModes, numVars x numCells] order
+        Args:
+            projector: 2D NumPy array containing linear projector. 
+            full_dim_arr: NumPy array of full-dimensional vector to be projected.
+            transpose: If True, transposes projector before projecting full_dim_arr.
+
+        Returns:
+            NumPy array of low-dimensional projection of full_dim_arr.
         """
 
         if full_dim_arr.ndim == 2:
@@ -40,17 +52,21 @@ class ProjectionROM(RomModel):
         return code_out
 
     def calc_rhs_low_dim(self, rom_domain, sol_domain):
-        """
-        Project RHS onto low-dimensional space for explicit time integrators
+        """Project RHS onto low-dimensional space for explicit time integrators.
 
-        Assumes that RHS term is scaled using an appropriate conservative
-        variable normalization profile
+        This is a helper function called from RomDomain.advance_subiter() for explicit time integration.
+        Child classes which enable explicit time integration must implement a calc_projector() member function
+        to compute the projector attribute.
+
+        Args:
+            rom_domain: RomDomain within which this RomModel is contained.
+            sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
         """
 
         # scale RHS
         norm_sub_prof = np.zeros(self.norm_fac_prof_cons.shape, dtype=REAL_TYPE)
 
-        rhs_scaled = self.standardize_data(
+        rhs_scaled = self.scale_profile(
             sol_domain.sol_int.rhs[self.var_idxs[:, None], sol_domain.direct_samp_idxs[None, :]],
             normalize=True,
             norm_fac_prof=self.norm_fac_prof_cons[:, sol_domain.direct_samp_idxs],

--- a/perform/rom/projection_rom/projection_rom.py
+++ b/perform/rom/projection_rom/projection_rom.py
@@ -8,7 +8,7 @@ class ProjectionROM(RomModel):
     """Base class for projection-based reduced-order models.
 
     Inherits from RomModel. This class makes no assumption on the form of the decoder,
-    but assumes a linear projection onto the low-dimensional space. 
+    but assumes a linear projection onto the low-dimensional space.
 
     Args:
         model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
@@ -29,7 +29,7 @@ class ProjectionROM(RomModel):
         Further assumes that projector is already in [latent_dim, num_vars x num_cells] order.
 
         Args:
-            projector: 2D NumPy array containing linear projector. 
+            projector: 2D NumPy array containing linear projector.
             full_dim_arr: NumPy array of full-dimensional vector to be projected.
             transpose: If True, transposes projector before projecting full_dim_arr.
 

--- a/perform/rom/rom_domain.py
+++ b/perform/rom/rom_domain.py
@@ -344,7 +344,7 @@ class RomDomain:
 
         sol_domain.sol_int.res_norm_l2 = norm_l2
         sol_domain.sol_int.resNormL1 = norm_l1
-        sol_domain.sol_int.res_norm_history[solver.iter - 1, :] = [norm_l2, norm_l1]
+        sol_domain.sol_int.res_norm_hist[solver.iter - 1, :] = [norm_l2, norm_l1]
 
     def set_model_flags(self):
         """Set universal ROM method flags that dictate various execution behaviors.

--- a/perform/rom/rom_domain.py
+++ b/perform/rom/rom_domain.py
@@ -24,7 +24,7 @@ class RomDomain:
     When running a ROM simulation, perform.driver.main() will generate a RomDomain for each SolutionDomain for which
     a ROM simulation is requested. The RomDomain will handle reading in the input parameters from the ROM parameter
     input file, checking the validity of these parameters, and initializing all requested RomModel's.
-    
+
     During simulation runtime, RomDomain is responsible for executing most of each RomModel's higher-level functions
     and executing accessory functions, e.g. filtering. Beyond this, member functions of RomDomain generally handle
     operations that apply to the entire ROM solution, e.g. time integration, calculating residual norms, etc.
@@ -216,7 +216,7 @@ class RomDomain:
 
         Args:
             sol_domain: SolutionDomain with which this RomDomain is associated.
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         print("Iteration " + str(solver.iter))
@@ -248,7 +248,7 @@ class RomDomain:
 
         Args:
             sol_domain: SolutionDomain with which this RomDomain is associated.
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         sol_int = sol_domain.sol_int
@@ -348,7 +348,7 @@ class RomDomain:
 
     def set_model_flags(self):
         """Set universal ROM method flags that dictate various execution behaviors.
-        
+
         If a new RomModel is created, its flags should be set here.
         """
 
@@ -581,10 +581,8 @@ class RomDomain:
         num_cells = sol_domain.mesh.num_cells
         num_samp_cells = sol_domain.num_samp_cells
         num_elements_center = gas.num_eqs ** 2 * num_samp_cells
-        col_offset = 0
         if sol_domain.direct_samp_idxs[0] == 0:
             num_elements_lower = gas.num_eqs ** 2 * (num_samp_cells - 1)
-            col_offset = 1
         else:
             num_elements_lower = num_elements_center
         if sol_domain.direct_samp_idxs[-1] == (num_cells - 1):

--- a/perform/rom/rom_domain.py
+++ b/perform/rom/rom_domain.py
@@ -22,8 +22,8 @@ class RomDomain:
     for separate models is necessary.
 
     When running a ROM simulation, perform.driver.main() will generate a RomDomain for each SolutionDomain for which
-    a ROM simulation is requested. The RomDomain will handle reading in the input parameters from rom_params.inp,
-    checking the validity of these parameters, and initializing all requested RomModel's.
+    a ROM simulation is requested. The RomDomain will handle reading in the input parameters from the ROM parameter
+    input file, checking the validity of these parameters, and initializing all requested RomModel's.
     
     During simulation runtime, RomDomain is responsible for executing most of each RomModel's higher-level functions
     and executing accessory functions, e.g. filtering. Beyond this, member functions of RomDomain generally handle
@@ -34,7 +34,7 @@ class RomDomain:
         solver: SystemSolver containing global simulation parameters.
 
     Attributes:
-        rom_dict: Dictionary of parameters read from rom_params.inp.
+        rom_dict: Dictionary of parameters read from ROM parameter input file.
         rom_method: String of ROM method to be applied (e.g. "LinearGalerkinProj").
         num_models: Number of separate models encapsulated by RomDomain.
         latent_dims: List of latent variable dimensions for each RomModel.

--- a/perform/rom/rom_domain.py
+++ b/perform/rom/rom_domain.py
@@ -9,16 +9,78 @@ from perform.solution.solution_phys import SolutionPhys
 from perform.time_integrator import get_time_integrator
 from perform.rom import get_rom_model
 
-# TODO: when moving to multi-domain, it may be useful to just
-# 	hold a sol_domain inside RomDomain for the associated full-dim solution
-# 	Still a pain to move around since it's associated with the RomDomain
-# 	and not the romModel, but whatever
-# TODO: need to eliminate normSubProf, just roll it into centProf (or reverse)
-
 
 class RomDomain:
-    """
-    Container class for ROM parameters and romModels
+    """Container class for all ROM models to be applied within a given SolutionDomain.
+
+    The concept of a ROM solution being composed of multiple ROM models derives from the concept of
+    "vector" vs. "scalar" ROMs initially referenced by Yuxiang Zhou in their 2010 Master's thesis.
+    The "vector" concept follows the most common scenario in which a ROM provides a single mapping from a
+    low-dimensional state to the complete physical state vector. The "scalar" concept is less common, whereby
+    several ROM models map to separate subsets of the physical state variables (e.g. one model maps to density
+    and energy, while another maps to momentum and density-weighted species mass fraction). Thus, some container
+    for separate models is necessary.
+
+    When running a ROM simulation, perform.driver.main() will generate a RomDomain for each SolutionDomain for which
+    a ROM simulation is requested. The RomDomain will handle reading in the input parameters from rom_params.inp,
+    checking the validity of these parameters, and initializing all requested RomModel's.
+    
+    During simulation runtime, RomDomain is responsible for executing most of each RomModel's higher-level functions
+    and executing accessory functions, e.g. filtering. Beyond this, member functions of RomDomain generally handle
+    operations that apply to the entire ROM solution, e.g. time integration, calculating residual norms, etc.
+
+    Args:
+        sol_domain: SolutionDomain with which this RomDomain is associated.
+        solver: SystemSolver containing global simulation parameters.
+
+    Attributes:
+        rom_dict: Dictionary of parameters read from rom_params.inp.
+        rom_method: String of ROM method to be applied (e.g. "LinearGalerkinProj").
+        num_models: Number of separate models encapsulated by RomDomain.
+        latent_dims: List of latent variable dimensions for each RomModel.
+        model_var_idxs: List of list of zero-indexed indices indicating which state variables each RomModel maps to.
+        model_dir: String path to directory containing all files required to execute each RomModel.
+        model_files:
+            list of strings of file names associated with each RomModel's primary data structure
+            (e.g. a linear model's trail basis), relative to model_dir.
+        cent_ic: Boolean flag of whether the initial condition file should be used to center the solution profile.
+        norm_sub_cons_in:
+            list of strings of file names associated with each RomModel's conservative variable subtractive
+            normalization profile, if needed, relative to model_dir.
+        norm_fac_cons_in:
+            list of strings of file names associated with each RomModel's conservative variable divisive
+            normalization profile, if needed, relative to model_dir.
+        cent_cons_in:
+            list of strings of file names associated with each RomModel's conservative variable centering profile,
+            if needed, relative to model_dir.
+        norm_sub_prim_in:
+            list of strings of file names associated with each RomModel's primitive variable subtractive
+            normalization profile, if needed, relative to model_dir.
+        norm_fac_prim_in:
+            list of strings of file names associated with each RomModel's primitive variable divisive
+            normalization profile, if needed, relative to model_dir.
+        cent_prim_in:
+            list of strings of file names associated with each RomModel's primitive variable centering profile
+            if needed, relative to model_dir.
+        has_time_integrator: Boolean flag indicating whether a given rom_method requires numerical time integration.
+        is_intrusive:
+            Boolean flag indicating whether a given rom_method is intrusive,
+            i.e. requires computation of the governing equations RHS and its Jacobian.
+        target_cons: Boolean flag indicating whether a given rom_method maps to the conservative variables.
+        target_prim: Boolean flag indicating whether a given rom_method maps to the primitive variables.
+        has_cons_norm:
+            Boolean flag indicating whether a given rom_method requires conservative variable normalization profiles.
+        has_cons_cent:
+            Boolean flag indicating whether a given rom_method requires conservative variable centering profiles.
+        has_prim_norm:
+            Boolean flag indicating whether a given rom_method requires primitive variable normalization profiles.
+        has_prim_cent:
+            Boolean flag indicating whether a given rom_method requires primitive variable centering profiles.
+        hyper_reduc: Boolean flag indicating whether hyper-reduction is to be used for an intrusive rom_method.
+        model_list: list containing num_models RomModel objects associated with this RomDomain.
+        low_dim_init_files:
+            list of strings of file names associated with low-dimensional state initialization profiles
+            for each RomModel.
     """
 
     def __init__(self, sol_domain, solver):
@@ -95,12 +157,11 @@ class RomDomain:
 
         self.set_model_flags()
 
-        self.adaptive_rom = catch_input(rom_dict, "adaptive_rom", False)
-
         # Set up hyper-reduction, if necessary
-        self.hyper_reduc = catch_input(rom_dict, "hyper_reduc", False)
-        if self.is_intrusive and self.hyper_reduc:
-            self.load_hyper_reduc(sol_domain)
+        if self.is_intrusive:
+            self.hyper_reduc = catch_input(rom_dict, "hyper_reduc", False)
+            if self.hyper_reduc:
+                self.load_hyper_reduc(sol_domain)
 
         # Get time integrator, if necessary
         # TODO: time_scheme should be specific to RomDomain, not the solver
@@ -146,8 +207,16 @@ class RomDomain:
         sol_domain.sol_int.sol_hist_prim = [sol_domain.sol_int.sol_prim.copy()] * (self.time_integrator.time_order + 1)
 
     def advance_iter(self, sol_domain, solver):
-        """
-        Advance low-dimensional state forward one time iteration
+        """Advance low-dimensional state and full solution forward one physical time iteration.
+
+        For non-intrusive ROMs without a time integrator, simply advances the solution one step.
+
+        For intrusive and non-intrusive ROMs with a time integrator, begins numerical time integration
+        and steps through sub-iterations.
+
+        Args:
+            sol_domain: SolutionDomain with which this RomDomain is associated.
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         print("Iteration " + str(solver.iter))
@@ -173,8 +242,13 @@ class RomDomain:
         self.update_code_hist()
 
     def advance_subiter(self, sol_domain, solver):
-        """
-        Advance physical solution forward one subiteration of time integrator
+        """Advance physical solution forward one subiteration of time integrator.
+
+        For intrusive ROMs, computes RHS and RHS Jacobian (if necessary).
+
+        Args:
+            sol_domain: SolutionDomain with which this RomDomain is associated.
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         sol_int = sol_domain.sol_int
@@ -218,9 +292,7 @@ class RomDomain:
             sol_int.update_state(from_cons=True)
 
     def update_code_hist(self):
-        """
-        Update low-dimensional state history after physical time step
-        """
+        """Update low-dimensional state history after physical time step."""
 
         for model in self.model_list:
 
@@ -228,11 +300,19 @@ class RomDomain:
             model.code_hist[0] = model.code.copy()
 
     def calc_code_res_norms(self, sol_domain, solver, subiter):
-        """
-        Calculate and print linear solve residual norms
+        """Calculate and print low-dimensional linear solve residual norms.
 
-        Note that output is ORDER OF MAGNITUDE of residual norm
-        (i.e. 1e-X, where X is the order of magnitude)
+        Computes L2 and L1 norms of low-dimensional linear solve residuals for each RomModel,
+        as computed in advance_subiter(). These are averaged across all RomModels and printed to the terminal,
+        and are used in advance_iter() to determine whether the Newton's method iterative solve has
+        converged sufficiently. If the norm is below numerical precision, it defaults to 1e-16.
+
+        Note that terminal output is ORDER OF MAGNITUDE (i.e. 1e-X, where X is the order of magnitude).
+
+        Args:
+            sol_domain: SolutionDomain with which this RomDomain is associated.
+            solver: SystemSolver containing global simulation parameters.
+            subiter: Current subiteration number within current time step's Newton's method iterative solve.
         """
 
         # Compute residual norm for each model
@@ -258,6 +338,7 @@ class RomDomain:
         else:
             norm_out_l1 = np.log10(norm_l1)
 
+        # Print to terminal
         out_string = (str(subiter + 1) + ":\tL2: %18.14f, \tL1: %18.14f") % (norm_out_l2, norm_out_l1,)
         print(out_string)
 
@@ -266,8 +347,9 @@ class RomDomain:
         sol_domain.sol_int.res_norm_history[solver.iter - 1, :] = [norm_l2, norm_l1]
 
     def set_model_flags(self):
-        """
-        Set universal ROM method flags that dictate various execution behaviors
+        """Set universal ROM method flags that dictate various execution behaviors.
+        
+        If a new RomModel is created, its flags should be set here.
         """
 
         self.has_time_integrator = False
@@ -325,9 +407,19 @@ class RomDomain:
         assert self.target_cons != self.target_prim, "Model must target either the primitive or conservative variables"
 
     def load_hyper_reduc(self, sol_domain):
-        """
-        Loads direct sampling indices and
-        determines cell indices for calculating fluxes and gradients
+        """Loads direct sampling indices and determines cell indices for hyper-reduction array slicing.
+
+        Numerous array slicing indices are required for various operations in efficiently computing
+        the non-linear RHS term, such as calculating fluxes, gradients, source terms, etc. as well as for computing
+        the RHS Jacobian if required. These slicing arrays are first generated here based on the initial sampling
+        indices, but may later be updated during sampling adaptation.
+
+        Todos:
+            Many of these operations should be moved to their own separate functions when
+            recomputing sampling for adaptive sampling.
+
+        Args:
+            sol_domain: SolutionDomain with which this RomDomain is associated.
         """
 
         # TODO: add some explanations for what each index array accomplishes
@@ -352,8 +444,6 @@ class RomDomain:
         assert (
             len(np.unique(sol_domain.direct_samp_idxs)) == sol_domain.num_samp_cells
         ), "Sampling indices must be unique"
-
-        # TODO: should probably shunt these over to a function for when indices get updated in adaptive method
 
         # Compute indices for inviscid flux calculations
         # NOTE: have to account for fact that boundary cells are prepended/appended
@@ -505,7 +595,6 @@ class RomDomain:
         row_idxs_lower = np.zeros(num_elements_lower, dtype=np.int32)
         col_idxs_lower = np.zeros(num_elements_lower, dtype=np.int32)
 
-        # TODO: definitely a faster way to do this
         lin_idx_A = 0
         lin_idx_B = 0
         lin_idx_C = 0

--- a/perform/rom/rom_model.py
+++ b/perform/rom/rom_model.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import numpy as np
 
@@ -6,15 +7,42 @@ from perform.constants import REAL_TYPE
 
 
 class RomModel:
-    """
-    Base class for any ROM model
+    """Base class for all ROM models.
 
-    Assumed that every model may be equipped with
-    some sort of data standardization requirement
+    The RomModel class provides basic functionality that every ROM model should be equipped with,
+    most importantly feature scaling and mapping from the low-dimensional state to
+    the high-dimensional state ("decoding"). Feature scaling is general, but decoding operations
+    are specific to child classes. Thus, RomModel only provides the high-level utility decode_sol(),
+    which calls child class implementations of apply_decoder().
+    
+    Args:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        rom_domain: RomDomain within which this RomModel is contained.
+        sol_domain: SolutionDomain with which this RomModel's RomDomain is associated.
 
-    Also assumed that every model has some means of
-    computing the full-dimensional state from the low
-    dimensional state, i.e. a "decoder"
+    Attributes:
+        model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
+        latent_dim: Dimension of low-dimensional code associated with this model.
+        var_idxs: NumPy array of zero-indexed indices of state variables which this model maps to.
+        num_vars: Number of state variables this model maps to.
+        num_cells: Number of finite volume cells in associated SolutionDomain.
+        sol_shape: Tuple shape (num_vars, num_cells) of full-dimensional state which this model maps to.
+        target_cons: Boolean flag indicating whether this model maps to the conservative variables.
+        code: NumPy array of unsteady low-dimensional state associated with this model.
+        res: 
+            NumPy array of low-dimensional linear solve residual when integrating ROM ODE in time
+            with an implicit time integrator.
+        norm_sub_prof_cons:
+            NumPy array of conservative variable subtractive normalization profile,
+            if required by ROM method.
+        norm_fac_prof_cons:
+            NumPy array of conservative variable divisive normalization profile, if required by ROM method.
+        cent_prof_cons: NumPy array of conservative variable centering profile, if required by ROM method.
+        norm_sub_prof_prim:
+            NumPy array of primitive variable subtractive normalization profile, if required by ROM method.
+        norm_fac_prof_prim:
+        NumPy array of primitive variable divisive normalization profile, if required by ROM method.
+        cent_prof_prim: NumPy array of primitive variable centering profile, if required by ROM method.
     """
 
     def __init__(self, model_idx, rom_domain, sol_domain):
@@ -27,9 +55,8 @@ class RomModel:
         self.sol_shape = (self.num_vars, self.num_cells)
 
         # Just copy some stuff for less clutter
-        self.model_dir = rom_domain.model_dir
+        model_dir = rom_domain.model_dir
         self.target_cons = rom_domain.target_cons
-        self.hyper_reduc = rom_domain.hyper_reduc
 
         self.code = np.zeros(self.latent_dim, dtype=REAL_TYPE)
         self.res = np.zeros(self.latent_dim, dtype=REAL_TYPE)
@@ -42,21 +69,21 @@ class RomModel:
         self.cent_prof_cons = None
         self.cent_prof_prim = None
         if rom_domain.has_cons_norm:
-            self.norm_sub_prof_cons = self.load_standardization(
-                os.path.join(self.model_dir, rom_domain.norm_sub_cons_in[self.model_idx]), default="zeros"
+            self.norm_sub_prof_cons = self.load_feature_scaling(
+                os.path.join(model_dir, rom_domain.norm_sub_cons_in[self.model_idx]), default="zeros"
             )
 
-            self.norm_fac_prof_cons = self.load_standardization(
-                os.path.join(self.model_dir, rom_domain.norm_fac_cons_in[self.model_idx]), default="ones"
+            self.norm_fac_prof_cons = self.load_feature_scaling(
+                os.path.join(model_dir, rom_domain.norm_fac_cons_in[self.model_idx]), default="ones"
             )
 
         if rom_domain.has_prim_norm:
-            self.norm_sub_prof_prim = self.load_standardization(
-                os.path.join(self.model_dir, rom_domain.norm_sub_prim_in[self.model_idx]), default="zeros"
+            self.norm_sub_prof_prim = self.load_feature_scaling(
+                os.path.join(model_dir, rom_domain.norm_sub_prim_in[self.model_idx]), default="zeros"
             )
 
-            self.norm_fac_prof_prim = self.load_standardization(
-                os.path.join(self.model_dir, rom_domain.norm_fac_prim_in[self.model_idx]), default="ones"
+            self.norm_fac_prof_prim = self.load_feature_scaling(
+                os.path.join(model_dir, rom_domain.norm_fac_prim_in[self.model_idx]), default="ones"
             )
 
         # Get centering profiles, if necessary
@@ -66,47 +93,81 @@ class RomModel:
                 self.cent_prof_cons = sol_domain.sol_int.sol_cons[self.var_idxs, :].copy()
 
             else:
-                self.cent_prof_cons = self.load_standardization(
-                    os.path.join(self.model_dir, rom_domain.cent_cons_in[self.model_idx]), default="zeros"
+                self.cent_prof_cons = self.load_feature_scaling(
+                    os.path.join(model_dir, rom_domain.cent_cons_in[self.model_idx]), default="zeros"
                 )
 
         if rom_domain.has_prim_cent:
             if rom_domain.cent_ic:
                 self.cent_prof_prim = sol_domain.sol_int.sol_prim[self.var_idxs, :].copy()
             else:
-                self.cent_prof_prim = self.load_standardization(
-                    os.path.join(self.model_dir, rom_domain.cent_prim_in[self.model_idx]), default="zeros"
+                self.cent_prof_prim = self.load_feature_scaling(
+                    os.path.join(model_dir, rom_domain.cent_prim_in[self.model_idx]), default="zeros"
                 )
 
-    def load_standardization(self, stand_input, default="zeros"):
+    def load_feature_scaling(self, scaling_input, default="zeros"):
+        """Load a normalization or centering profile from NumPy binary.
+
+        Args:
+            scaling_input: String path to scaling profile NumPy binary.
+            default: String indicating default profile if loading fails due to size mismatch or load failure.
+
+        Returns:
+            scaling_prof: NumPy array of scaling profile loaded (or default, if load failed).
+        """
 
         try:
-            # TODO: add ability to accept single scalar value for stand_input
-            # catch_list doesn't handle this when loading norm_sub_in, etc.
-
             # Load single complete standardization profile from file
-            stand_prof = np.load(stand_input)
-            assert stand_prof.shape == self.sol_shape
-            return stand_prof
+            scaling_prof = np.load(scaling_input)
+            assert scaling_prof.shape == self.sol_shape
+            return scaling_prof
 
         except AssertionError:
-            print("Standardization profile at " + stand_input + " did not match solution shape")
+            print("Standardization profile at " + scaling_input + " did not match solution shape")
 
         if default == "zeros":
-            print("WARNING: standardization load failed or not specified," + " defaulting to zeros")
-            stand_prof = np.zeros(self.sol_shape, dtype=REAL_TYPE)
+            print("WARNING: standardization load failed or not specified, defaulting to zeros")
+            time.sleep(1.0)
+            scaling_prof = np.zeros(self.sol_shape, dtype=REAL_TYPE)
         elif default == "ones":
-            print("WARNING: standardization load failed or not specified," + " defaulting to ones")
-            stand_prof = np.zeros(self.sol_shape, dtype=REAL_TYPE)
+            print("WARNING: standardization load failed or not specified, defaulting to ones")
+            time.sleep(1.0)
+            scaling_prof = np.zeros(self.sol_shape, dtype=REAL_TYPE)
+        else:
+            raise ValueError("Invalid default: " + str(default))
 
-        return stand_prof
+        return scaling_prof
 
-    def standardize_data(
-        self, arr, normalize=True, norm_fac_prof=None, norm_sub_prof=None, center=True, cent_prof=None, inverse=False
+    def scale_profile(
+        self, arr_in, normalize=True, norm_fac_prof=None, norm_sub_prof=None, center=True, cent_prof=None, inverse=False
     ):
+        """(De-)centers and/or (de-)normalizes solution profile.
+
+        Depending on argument flags, centers and/or normalizes solution profile, or de-normalizes
+        and/or de-centers solution profile.
+
+        If inverse is False:
+            arr = (arr_in - cent_prof - norm_sub_prof) / norm_fac_prof
+
+        If inverse is True:
+            arr = arr_in * norm_fac_prof + norm_sub_prof + cent_prof
+
+        Args:
+            arr_in: NumPy array of solution profile to be scaled.
+            normalize: Boolean flag indicating whether arr_in should be (de-)normalized.
+            norm_fac_prof: NumPy array of divisive normalization profile.
+            norm_sub_prof: NumPy array of subtractive normalization profile.
+            center: Boolean flag indicating whether arr_in should be (de-)centered.
+            cent_prof: NumPy array of centering profile.
+            inverse: If True, de-normalize and de-center. If False, center and normalize.
+
+        Returns:
+            (De)-centered and/or (de)-normalized copy of arr_in.
         """
-        (de)centering and (de)normalization
-        """
+
+        arr = arr_in.copy()
+
+        assert normalize or center, "Must either (de-)center or (de-)normalize."
 
         if normalize:
             assert norm_fac_prof is not None, "Must provide normalization division factor to normalize"
@@ -114,11 +175,14 @@ class RomModel:
         if center:
             assert cent_prof is not None, "Must provide centering profile to center"
 
+        # de-normalize and de-center
         if inverse:
             if normalize:
                 arr = self.normalize(arr, norm_fac_prof, norm_sub_prof, denormalize=True)
             if center:
                 arr = self.center(arr, cent_prof, decenter=True)
+
+        # center and normalize
         else:
             if center:
                 arr = self.center(arr, cent_prof, decenter=False)
@@ -127,39 +191,60 @@ class RomModel:
 
         return arr
 
-    def center(self, arr, cent_prof, decenter=False):
-        """
-        (de)center input vector according to loaded centering profile
+    def center(self, arr_in, cent_prof, decenter=False):
+        """(De)center input vector according to provided centering profile.
+
+        Args:
+            arr_in: NumPy array to be (de-)centered.
+            cent_prof: NumPy array of centering profile.
+            decenter: If True, decenter profile. If False, center profile.
+        
+        Returns:
+            (De-)centered copy of arr_in.
         """
 
         if decenter:
-            arr += cent_prof
+            arr = arr_in + cent_prof
         else:
-            arr -= cent_prof
+            arr = arr_in - cent_prof
         return arr
 
-    def normalize(self, arr, norm_fac_prof, norm_sub_prof, denormalize=False):
-        """
-        (De)normalize input vector according to
-        subtractive and divisive normalization profiles
+    def normalize(self, arr_in, norm_fac_prof, norm_sub_prof, denormalize=False):
+        """(De)normalize input vector according to subtractive and divisive normalization profiles.
+
+        Args:
+            arr_in: NumPy array to be (de-)normalized.
+            norm_fac_prof: NumPy array of divisive normalization profile.
+            norm_sub_prof: NumPy array of subtractive normalization profile.
+            denormalize: If True, denormalize profile. If False, normalize profile.
+
+        Returns:
+            (De-)normalized copy of arr_in.
         """
 
         if denormalize:
-            arr = arr * norm_fac_prof + norm_sub_prof
+            arr = arr_in * norm_fac_prof + norm_sub_prof
         else:
-            arr = (arr - norm_sub_prof) / norm_fac_prof
+            arr = (arr_in - norm_sub_prof) / norm_fac_prof
         return arr
 
     def decode_sol(self, code_in):
-        """
-        Compute full decoding of solution,
-        including decentering and denormalization
+        """Compute full decoding of solution, including de-centering and de-normalization.
+
+        Maps low-dimensional code to full-dimensional state, and de-centers and de-normalizes.
+        Note that the apply_decoder is implemented within child classes, as these are specific to ROM method.
+
+        Args:
+            code_in: low-dimensional code to be decoded.
+
+        Returns:
+            Full-dimensional solution NumPy array resulting from decoding and de-scaling.
         """
 
         sol = self.apply_decoder(code_in)
 
         if self.target_cons:
-            sol = self.standardize_data(
+            sol = self.scale_profile(
                 sol,
                 normalize=True,
                 norm_fac_prof=self.norm_fac_prof_cons,
@@ -170,7 +255,7 @@ class RomModel:
             )
 
         else:
-            sol = self.standardize_data(
+            sol = self.scale_profile(
                 sol,
                 normalize=True,
                 norm_fac_prof=self.norm_fac_prof_prim,
@@ -183,8 +268,14 @@ class RomModel:
         return sol
 
     def update_sol(self, sol_domain):
-        """
-        Update solution after code has been updated
+        """Update solution after low-dimensional code has been updated.
+
+        Helper function that updates full-dimensional state within the given SolutionDomain. 
+        This function is called within RomDomain.advance_subiter() for those ROM methods with a time integrator,
+        and within RomDomain.advance_iter() for non-intrusive methods without a time integrator. 
+
+        Args:
+            sol_domain: SolutionDomain with which this RomModel's containing RomDomain is associated.
         """
 
         if self.target_cons:
@@ -193,11 +284,14 @@ class RomModel:
             sol_domain.sol_int.sol_prim[self.var_idxs, :] = self.decode_sol(self.code)
 
     def calc_code_norms(self):
-        """
-        Compute L1 and L2 norms of low-dimensional state
-        linear solve residuals
+        """Compute L1 and L2 norms of low-dimensional state linear solve residuals
 
-        Scaled by number of elements, so "L2 norm" here is really RMS
+        This function is called within RomDomain.calc_code_res_norms(), after which the residual norms are averaged
+        across all models for an aggregate measure. Note that this measure is scaled by number of elements,
+        so "L2 norm" here is really RMS. 
+
+        Returns:
+            The L2 and L1 norms of the low-dimensional linear solve residual.
         """
 
         res_abs = np.abs(self.res)

--- a/perform/rom/rom_model.py
+++ b/perform/rom/rom_model.py
@@ -14,7 +14,7 @@ class RomModel:
     the high-dimensional state ("decoding"). Feature scaling is general, but decoding operations
     are specific to child classes. Thus, RomModel only provides the high-level utility decode_sol(),
     which calls child class implementations of apply_decoder().
-    
+
     Args:
         model_idx: Zero-indexed ID of a given RomModel instance within a RomDomain's model_list.
         rom_domain: RomDomain within which this RomModel is contained.
@@ -29,7 +29,7 @@ class RomModel:
         sol_shape: Tuple shape (num_vars, num_cells) of full-dimensional state which this model maps to.
         target_cons: Boolean flag indicating whether this model maps to the conservative variables.
         code: NumPy array of unsteady low-dimensional state associated with this model.
-        res: 
+        res:
             NumPy array of low-dimensional linear solve residual when integrating ROM ODE in time
             with an implicit time integrator.
         norm_sub_prof_cons:
@@ -198,7 +198,7 @@ class RomModel:
             arr_in: NumPy array to be (de-)centered.
             cent_prof: NumPy array of centering profile.
             decenter: If True, decenter profile. If False, center profile.
-        
+
         Returns:
             (De-)centered copy of arr_in.
         """
@@ -270,9 +270,9 @@ class RomModel:
     def update_sol(self, sol_domain):
         """Update solution after low-dimensional code has been updated.
 
-        Helper function that updates full-dimensional state within the given SolutionDomain. 
+        Helper function that updates full-dimensional state within the given SolutionDomain.
         This function is called within RomDomain.advance_subiter() for those ROM methods with a time integrator,
-        and within RomDomain.advance_iter() for non-intrusive methods without a time integrator. 
+        and within RomDomain.advance_iter() for non-intrusive methods without a time integrator.
 
         Args:
             sol_domain: SolutionDomain with which this RomModel's containing RomDomain is associated.
@@ -288,7 +288,7 @@ class RomModel:
 
         This function is called within RomDomain.calc_code_res_norms(), after which the residual norms are averaged
         across all models for an aggregate measure. Note that this measure is scaled by number of elements,
-        so "L2 norm" here is really RMS. 
+        so "L2 norm" here is really RMS.
 
         Returns:
             The L2 and L1 norms of the low-dimensional linear solve residual.

--- a/perform/rom/tf_keras_funcs.py
+++ b/perform/rom/tf_keras_funcs.py
@@ -1,5 +1,5 @@
-# Collection of generic functions that
-# 	any TensorFlow-Keras model-based method can use
+""""Collection of generic functions that any TensorFlow-Keras model-based method can use"""
+
 import os
 
 import tensorflow as tf
@@ -7,10 +7,18 @@ from tensorflow.keras.models import load_model
 
 
 def init_device(run_gpu):
-    """
-    If running on GPU, limit GPU memory growth
+    """Initializes GPU execution, if requested
+    
+    TensorFlow 2+ can execute from CPU or GPU, this function does some prep work.
+    
+    Passing run_gpu=True will limit GPU memory growth, as unlimited TensorFlow memory allocation can be
+    quite aggressive on first call.
+    
+    Passing run_gpu=False will guarantee that TensorFlow runs on the CPU. Even if GPUs are available,
+    this will hide those devices from the TensorFlow runtime.
 
-    If running on CPU, hide any GPUs from TF
+    Args:
+        run_gpu: Boolean flag indicating whether to execute TensorFlow functions on an available GPU.
     """
 
     if run_gpu:
@@ -32,8 +40,13 @@ def init_device(run_gpu):
 
 
 def load_model_obj(model_path):
-    """
-    Load Keras SavedModel object from file specified by model_path
+    """Load Keras model object from file
+    
+    This function loads a trained Keras model from the older Keras H5 format.
+    This does not accommodate the newer TensorFlow SavedModel format.
+
+    Args:
+        model_path: string path to *.h5 model file to be loaded.
     """
 
     model_obj = load_model(model_path, compile=False)
@@ -41,9 +54,14 @@ def load_model_obj(model_path):
 
 
 def get_io_shape(shape):
-    """
-    Gets model I/O shape, handles situations in which
-    layer shape is returned as a list instead of a tuple
+    """Gets Keras model I/O shape.
+    
+    This takes in the output of tf.keras.Model.Layer.input_shape or tf.keras.Model.Layer.output_shape.
+    If the shape is already a tuple, simply returns the shape.
+    If the shape is a list (as occasionally happens), it returns the shape tuple associated with this list.
+
+    Args:
+        shape: output of tf.keras.Model.Layer.input_shape or tf.keras.Model.Layer.output_shape
     """
 
     if type(shape) is list:

--- a/perform/rom/tf_keras_funcs.py
+++ b/perform/rom/tf_keras_funcs.py
@@ -8,12 +8,12 @@ from tensorflow.keras.models import load_model
 
 def init_device(run_gpu):
     """Initializes GPU execution, if requested
-    
+
     TensorFlow 2+ can execute from CPU or GPU, this function does some prep work.
-    
+
     Passing run_gpu=True will limit GPU memory growth, as unlimited TensorFlow memory allocation can be
     quite aggressive on first call.
-    
+
     Passing run_gpu=False will guarantee that TensorFlow runs on the CPU. Even if GPUs are available,
     this will hide those devices from the TensorFlow runtime.
 
@@ -29,7 +29,6 @@ def init_device(run_gpu):
                 # Currently, memory growth needs to be the same across GPUs
                 for gpu in gpus:
                     tf.config.experimental.set_memory_growth(gpu, True)
-                    logical_gpus = tf.config.experimental.list_logical_devices("GPU")
             except RuntimeError as e:
                 # Memory growth must be set before GPUs have been initialized
                 print(e)
@@ -41,7 +40,7 @@ def init_device(run_gpu):
 
 def load_model_obj(model_path):
     """Load Keras model object from file
-    
+
     This function loads a trained Keras model from the older Keras H5 format.
     This does not accommodate the newer TensorFlow SavedModel format.
 
@@ -55,7 +54,7 @@ def load_model_obj(model_path):
 
 def get_io_shape(shape):
     """Gets Keras model I/O shape.
-    
+
     This takes in the output of tf.keras.Model.Layer.input_shape or tf.keras.Model.Layer.output_shape.
     If the shape is already a tuple, simply returns the shape.
     If the shape is a list (as occasionally happens), it returns the shape tuple associated with this list.

--- a/perform/solution/solution_boundary/solution_boundary.py
+++ b/perform/solution/solution_boundary/solution_boundary.py
@@ -76,7 +76,7 @@ class SolutionBoundary(SolutionPhys):
 
     def calc_pert(self, sol_time):
         """Compute sinusoidal perturbation factor.
-        
+
         Args:
             sol_time: Current physical time, in seconds.
         """
@@ -92,9 +92,9 @@ class SolutionBoundary(SolutionPhys):
 
     def calc_boundary_state(self, sol_time, space_order, sol_prim=None, sol_cons=None):
         """Run boundary calculation and update ghost cell state.
-        
+
         Assumed that boundary function sets primitive state.
-        
+
         Args:
             sol_time: Current physical time, in seconds.
             space_order: Spatial order of accuracy of face reconstruction.

--- a/perform/solution/solution_boundary/solution_boundary.py
+++ b/perform/solution/solution_boundary/solution_boundary.py
@@ -8,15 +8,41 @@ from perform.input_funcs import parse_bc
 
 
 class SolutionBoundary(SolutionPhys):
-    """
-    Ghost cell solution
+    """Physical solution for boundary ghost cells.
+
+    This class provides a base for SolutionInlet and SolutionOutlet, reading input parameters,
+    initializing boundary state calculation functions, and executing those functions during the simulation runtime.
+
+    Each SolutionDomain includes two SolutionBoundary's: one SolutionInlet and one SolutionOutlet.
+
+    The interpretations of the attributes press, vel, temp, mass_fracs, and rho are generally ambiguous and rarely
+    represent such fixed values at the boundary. Please refer to the documentation for how to interpret each of these
+    values for a given boundary condition.
+
+    Args:
+        gas: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
+        solver: SystemSolver containing global simulation parameters.
+        bound_type: Either "inlet" or "outlet", for an inlet or outlet boundary ghost cell, respectively.
+
+    Attributes:
+        press: Pressure-related quantity, interpreted depending on boundary condition.
+        vel: Velocity-related quantity, interpreted depending on boundary condition.
+        temp: Temperature-related quantity, interpreted depending on boundary condition.
+        mass_fracs: Mass fraction-related quantity, interpreted depending on boundary condition.
+        rho: Density-related quantity, interpreted depending on boundary condition.
+        pert_type:
+            String name of the type of boundary perturbation to apply, interpreted depending on boundary condition.
+        pert_perc:
+            Percentage of the fixed boundary value about which to apply the boundary perturbation.
+            For example, a 10% perturbation would be supplied as 0.1.
+        pert_freq: List of superimposed frequencies at which to apply the boundary perturbation, in Hz
     """
 
     def __init__(self, gas, solver, bound_type):
 
         param_dict = solver.param_dict
 
-        # this generally stores fixed/stagnation properties
+        # Read input boundary values
         (
             self.press,
             self.vel,
@@ -33,13 +59,13 @@ class SolutionBoundary(SolutionPhys):
         ), "Must provide mass fraction state for all species at boundary"
         assert np.sum(self.mass_fracs) == 1.0, "Boundary mass fractions must sum to 1.0"
 
+        # Initialize thermodynamic properties
         self.cp_mix = gas.calc_mix_cp(self.mass_fracs[gas.mass_frac_slice, None])
         self.r_mix = gas.calc_mix_gas_constant(self.mass_fracs[gas.mass_frac_slice, None])
         self.gamma_mix = gas.calc_mix_gamma(self.r_mix, self.cp_mix)
         self.enth_ref_mix = gas.calc_mix_enth_ref(self.mass_fracs[gas.mass_frac_slice, None])
 
-        # this will be updated at each iteration, just initializing now
-        # TODO: number of ghost cells should not always be one
+        # This will be updated at each iteration, just initializing with a reasonable number
         sol_dummy = np.zeros((gas.num_eqs, 1), dtype=REAL_TYPE)
         sol_dummy[0, 0] = 1e6
         sol_dummy[1, 0] = 1.0
@@ -48,24 +74,32 @@ class SolutionBoundary(SolutionPhys):
         super().__init__(gas, 1, sol_prim_in=sol_dummy)
         self.sol_prim[3:, 0] = self.mass_fracs[gas.mass_frac_slice]
 
-    def calc_pert(self, t):
-        """
-        Compute sinusoidal perturbation factor
+    def calc_pert(self, sol_time):
+        """Compute sinusoidal perturbation factor.
+        
+        Args:
+            sol_time: Current physical time, in seconds.
         """
 
         # TODO: add phase offset
 
         pert = 0.0
         for f in self.pert_freq:
-            pert += sin(2.0 * pi * self.pert_freq * t)
+            pert += sin(2.0 * pi * self.pert_freq * sol_time)
         pert *= self.pert_perc
 
         return pert
 
     def calc_boundary_state(self, sol_time, space_order, sol_prim=None, sol_cons=None):
-        """
-        Run boundary calculation and update ghost cell state
-        Assumed that boundary function sets primitive state
+        """Run boundary calculation and update ghost cell state.
+        
+        Assumed that boundary function sets primitive state.
+        
+        Args:
+            sol_time: Current physical time, in seconds.
+            space_order: Spatial order of accuracy of face reconstruction.
+            sol_prim: NumPy array of SolutionInterior.sol_prim, the primitive state profile.
+            sol_cons: NumPy array of SolutionInterior.sol_cons, the conservative state profile.
         """
 
         self.bound_func(sol_time, space_order, sol_prim=sol_prim, sol_cons=sol_cons)

--- a/perform/solution/solution_boundary/solution_inlet.py
+++ b/perform/solution/solution_boundary/solution_inlet.py
@@ -37,7 +37,7 @@ class SolutionInlet(SolutionBoundary):
 
     def calc_stagnation_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
         """Specify stagnation temperature and stagnation pressure.
-        
+
         Args:
             sol_time: Current physical time, in seconds.
             space_order: Spatial order of accuracy of face reconstruction.
@@ -112,9 +112,9 @@ class SolutionInlet(SolutionBoundary):
 
     def calc_full_state_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
         """Full state specification.
-        
+
         Mostly just for perturbing inlet state to check for outlet reflections.
-        
+
         Args:
             sol_time: Current physical time, in seconds.
             space_order: Spatial order of accuracy of face reconstruction.
@@ -141,9 +141,9 @@ class SolutionInlet(SolutionBoundary):
 
     def calc_mean_flow_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
         """Non-reflective mean-flow inlet.
-        
+
         Assumes that unsteady solution is a small perturbation about mean flow solution.
-        
+
         Args:
             sol_time: Current physical time, in seconds.
             space_order: Spatial order of accuracy of face reconstruction.
@@ -156,7 +156,6 @@ class SolutionInlet(SolutionBoundary):
         # Mean flow and infinitely-far upstream quantities
         press_up = self.press
         temp_up = self.temp
-        mass_fracs_up = self.mass_fracs[:-1]
         rho_c_mean = self.vel
         rho_cp_mean = self.rho
 

--- a/perform/solution/solution_boundary/solution_inlet.py
+++ b/perform/solution/solution_boundary/solution_inlet.py
@@ -4,8 +4,19 @@ from perform.solution.solution_boundary.solution_boundary import SolutionBoundar
 
 
 class SolutionInlet(SolutionBoundary):
-    """
-    Inlet ghost cell solution
+    """Inlet ghost cell solution.
+
+    Simply implements member functions for computing the ghost cell state according to a specific boundary condition.
+
+    Please refer to the solver theory documentation for details on each boundary condition.
+
+    Args:
+        gas: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
+        solver: SystemSolver containing global simulation parameters.
+
+    Attributes:
+        bound_cond: String specifying the boundary condition to be applied.
+        bound_func: Python function implementing the boundary condition specified by bound_cond.
     """
 
     def __init__(self, gas, solver):
@@ -13,7 +24,6 @@ class SolutionInlet(SolutionBoundary):
         param_dict = solver.param_dict
         self.bound_cond = param_dict["bound_cond_inlet"]
 
-        # Add assertions to check that required properties are specified
         if self.bound_cond == "stagnation":
             self.bound_func = self.calc_stagnation_bc
         elif self.bound_cond == "fullstate":
@@ -26,8 +36,13 @@ class SolutionInlet(SolutionBoundary):
         super().__init__(gas, solver, "inlet")
 
     def calc_stagnation_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
-        """
-        Specify stagnation temperature and stagnation pressure
+        """Specify stagnation temperature and stagnation pressure.
+        
+        Args:
+            sol_time: Current physical time, in seconds.
+            space_order: Spatial order of accuracy of face reconstruction.
+            sol_prim: NumPy array of SolutionInterior.sol_prim, the primitive state profile.
+            sol_cons: NumPy array of SolutionInterior.sol_cons, the conservative state profile.
         """
 
         assert sol_prim is not None, "Must provide primitive interior state"
@@ -75,9 +90,8 @@ class SolutionInlet(SolutionBoundary):
             print("Boundary velocity: " + str(vel_p1))
             raise ValueError("Non-physical inlet state")
 
-        # Solve quadratic formula, assign Mach number
-        # depending on sign/magnitude
-        # If only one positive, select that.
+        # Solve quadratic formula, assign Mach number depending on sign/magnitude
+        # If only one positive, select that
         # If both positive, select smaller
         rad = sqrt(rad)
         mach_1 = (-b_val - rad) / (2.0 * a_val)
@@ -97,9 +111,15 @@ class SolutionInlet(SolutionBoundary):
         self.sol_prim[1, 0] = mach_bound * c_bound
 
     def calc_full_state_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
-        """
-        Full state specification
-        Mostly just for perturbing inlet state to check for outlet reflections
+        """Full state specification.
+        
+        Mostly just for perturbing inlet state to check for outlet reflections.
+        
+        Args:
+            sol_time: Current physical time, in seconds.
+            space_order: Spatial order of accuracy of face reconstruction.
+            sol_prim: NumPy array of SolutionInterior.sol_prim, the primitive state profile.
+            sol_cons: NumPy array of SolutionInterior.sol_cons, the conservative state profile.
         """
 
         press_bound = self.press
@@ -120,10 +140,15 @@ class SolutionInlet(SolutionBoundary):
         self.sol_prim[2, 0] = temp_bound
 
     def calc_mean_flow_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
-        """
-        Non-reflective boundary, unsteady solution
-        is perturbation about mean flow solution
-        Refer to documentation for derivation
+        """Non-reflective mean-flow inlet.
+        
+        Assumes that unsteady solution is a small perturbation about mean flow solution.
+        
+        Args:
+            sol_time: Current physical time, in seconds.
+            space_order: Spatial order of accuracy of face reconstruction.
+            sol_prim: NumPy array of SolutionInterior.sol_prim, the primitive state profile.
+            sol_cons: NumPy array of SolutionInterior.sol_cons, the conservative state profile.
         """
 
         assert sol_prim is not None, "Must provide primitive interior state"

--- a/perform/solution/solution_boundary/solution_outlet.py
+++ b/perform/solution/solution_boundary/solution_outlet.py
@@ -4,8 +4,19 @@ from perform.solution.solution_boundary.solution_boundary import SolutionBoundar
 
 
 class SolutionOutlet(SolutionBoundary):
-    """
-    Outlet ghost cell solution
+    """Outlet ghost cell solution.
+
+    Simply implements member functions for computing the ghost cell state according to a specific boundary condition.
+
+    Please refer to the solver theory documentation for details on each boundary condition.
+
+    Args:
+        gas: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
+        solver: SystemSolver containing global simulation parameters.
+
+    Attributes:
+        bound_cond: String specifying the boundary condition to be applied.
+        bound_func: Python function implementing the boundary condition specified by bound_cond.
     """
 
     def __init__(self, gas, solver):
@@ -13,7 +24,6 @@ class SolutionOutlet(SolutionBoundary):
         param_dict = solver.param_dict
         self.bound_cond = param_dict["bound_cond_outlet"]
 
-        # add assertions to check that required properties are specified
         if self.bound_cond == "subsonic":
             self.bound_func = self.calc_subsonic_bc
         elif self.bound_cond == "meanflow":
@@ -24,8 +34,13 @@ class SolutionOutlet(SolutionBoundary):
         super().__init__(gas, solver, "outlet")
 
     def calc_subsonic_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
-        """
-        Subsonic outflow, specify outlet static pressure
+        """Specify outlet static pressure
+
+        Args:
+            sol_time: Current physical time, in seconds.
+            space_order: Spatial order of accuracy of face reconstruction.
+            sol_prim: NumPy array of SolutionInterior.sol_prim, the primitive state profile.
+            sol_cons: NumPy array of SolutionInterior.sol_cons, the conservative state profile.
         """
 
         # TODO: deal with mass fraction at outlet, should not be fixed
@@ -38,12 +53,12 @@ class SolutionOutlet(SolutionBoundary):
         if self.pert_type == "pressure":
             press_bound *= 1.0 + self.calc_pert(sol_time)
 
-        # chemical composition assumed constant near boundary
+        # Chemical composition assumed constant near boundary
         r_mix = self.r_mix[0]
         gamma_mix = self.gamma_mix[0]
         gamma_mix_m1 = gamma_mix - 1.0
 
-        # calculate interior state
+        # Calculate interior state
         press_p1 = sol_prim[0, -1]
         press_p2 = sol_prim[0, -2]
         rho_p1 = sol_cons[0, -1]
@@ -51,7 +66,7 @@ class SolutionOutlet(SolutionBoundary):
         vel_p1 = sol_prim[1, -1]
         vel_p2 = sol_prim[1, -2]
 
-        # outgoing characteristics information
+        # Outgoing characteristics information
         s_p1 = press_p1 / pow(rho_p1, gamma_mix)
         s_p2 = press_p2 / pow(rho_p2, gamma_mix)
         c_p1 = sqrt(gamma_mix * r_mix * sol_prim[2, -1])
@@ -59,7 +74,7 @@ class SolutionOutlet(SolutionBoundary):
         j_p1 = vel_p1 + 2.0 * c_p1 / gamma_mix_m1
         j_p2 = vel_p2 + 2.0 * c_p2 / gamma_mix_m1
 
-        # extrapolate to exterior
+        # Extrapolate to exterior
         if space_order == 1:
             s = s_p1
             j = j_p1
@@ -71,7 +86,7 @@ class SolutionOutlet(SolutionBoundary):
                 "Higher order extrapolation implementation " + "required for spatial order " + str(space_order)
             )
 
-        # compute exterior state
+        # Compute exterior state
         self.sol_prim[0, 0] = press_bound
         rho_bound = pow((press_bound / s), (1.0 / gamma_mix))
         c_bound = sqrt(gamma_mix * press_bound / rho_bound)
@@ -79,10 +94,15 @@ class SolutionOutlet(SolutionBoundary):
         self.sol_prim[2, 0] = press_bound / (r_mix * rho_bound)
 
     def calc_mean_flow_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
-        """
-        Non-reflective boundary, unsteady solution is
-        perturbation about mean flow solution
-        Refer to documentation for derivation
+        """Non-reflective mean flow outlet.
+        
+        Unsteady solution is assumed to be a small perturbation about mean flow solution.
+
+        Args:
+            sol_time: Current physical time, in seconds.
+            space_order: Spatial order of accuracy of face reconstruction.
+            sol_prim: NumPy array of SolutionInterior.sol_prim, the primitive state profile.
+            sol_cons: NumPy array of SolutionInterior.sol_cons, the conservative state profile.
         """
 
         assert sol_prim is not None, "Must provide primitive interior state"
@@ -94,18 +114,18 @@ class SolutionOutlet(SolutionBoundary):
         if self.pert_type == "pressure":
             press_back *= 1.0 + self.calc_pert(sol_time)
 
-        # interior quantities
+        # Interior quantities
         press_out = sol_prim[0, -2:]
         vel_out = sol_prim[1, -2:]
         temp_out = sol_prim[2, -2:]
         mass_frac_out = sol_prim[3:, -2:]
 
-        # characteristic variables
+        # Characteristic variables
         w_1_out = temp_out - press_out / rho_cp_mean
         w_2_out = vel_out + press_out / rho_c_mean
         w_4_out = mass_frac_out
 
-        # extrapolate to exterior
+        # Extrapolate to exterior
         if space_order == 1:
             w_1_bound = w_1_out[0]
             w_2_bound = w_2_out[0]

--- a/perform/solution/solution_boundary/solution_outlet.py
+++ b/perform/solution/solution_boundary/solution_outlet.py
@@ -95,7 +95,7 @@ class SolutionOutlet(SolutionBoundary):
 
     def calc_mean_flow_bc(self, sol_time, space_order, sol_prim=None, sol_cons=None):
         """Non-reflective mean flow outlet.
-        
+
         Unsteady solution is assumed to be a small perturbation about mean flow solution.
 
         Args:

--- a/perform/solution/solution_domain.py
+++ b/perform/solution/solution_domain.py
@@ -2,7 +2,6 @@ import os
 
 import numpy as np
 from scipy.sparse.linalg import spsolve
-from scipy.linalg import solve
 
 from perform.constants import REAL_TYPE
 from perform.input_funcs import get_initial_conditions, catch_list, catch_input, read_input_file
@@ -307,7 +306,7 @@ class SolutionDomain:
         For explicit time integrator, only computes RHS and advances solution explicitly.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         self.calc_rhs(solver)
@@ -351,7 +350,7 @@ class SolutionDomain:
         computes face fluxes and source term, and stores result in sol_int.rhs.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         sol_int = self.sol_int
@@ -450,14 +449,14 @@ class SolutionDomain:
         with respect to either the full primitive state vector (if dual_time == True) or the full conservative
         state vector (if dual_time == False). The contributions to the residual Jacobian from the time integrator,
         flux, and source terms are computed separately and combined.
-        
+
         Ultimately, the residual Jacobian can be represented as a block tri-diagonal matrix
         if the residual vector were flattened in column-major ordering. For the sake of computational efficiency,
         however, it is later formed into a roughly banded matrix corresponding to the residual vector being flattened
         in row-major ordering. This final reordering is performed via res_jacob_assemble().
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
 
         Returns:
             2D scipy.sparse.csr_matrix of the residual Jacobian, ordered in such a way as to correspond with a
@@ -587,7 +586,7 @@ class SolutionDomain:
         Update snapshot array at interval given by solver.out_interval if not running in "steady" mode.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         # Write restart files
@@ -611,10 +610,10 @@ class SolutionDomain:
         whether the "steady" solve has "converged" according to solver.steady_tol.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
 
         Returns:
-            Boolean flag indicating whether the "steady" solve has "converged". 
+            Boolean flag indicating whether the "steady" solve has "converged".
         """
 
         # Update convergence and field data file on disk
@@ -637,7 +636,7 @@ class SolutionDomain:
         are written to disk.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         if solver.solve_failed:
@@ -653,7 +652,7 @@ class SolutionDomain:
         """Update probe monitor array from current solution.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         # TODO: throw error for source probe in ghost cells
@@ -708,7 +707,7 @@ class SolutionDomain:
         """Save probe data to disk at end/failure of simulation.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         # Get output file name

--- a/perform/solution/solution_domain.py
+++ b/perform/solution/solution_domain.py
@@ -275,7 +275,7 @@ class SolutionDomain:
         Outputs iterations number, and for implicit time integrators, residual norms for iterative convergence.
 
         Args:
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
         """
 
         if not solver.run_steady:

--- a/perform/solution/solution_domain.py
+++ b/perform/solution/solution_domain.py
@@ -33,20 +33,75 @@ from perform.reaction_model.finite_rate_irrev_reaction import FiniteRateIrrevRea
 
 
 class SolutionDomain:
-    """
-    Container class for interior and boundary physical solutions
+    """Container class for governing equations solver objects and methods.
+
+    This class provides a broad container to hold just about everything related to the unsteady solution of
+    the governing PDE. This includes the SolutionPhys objects of the interior cells and boundary cells,
+    the Mesh, GasModel, Flux's, ReactionModel, TimeIntegrator, and Limiters needed to compute the unsteady solution,
+    and any parameters which govern the solver behavior its the spatial domain.
+
+    This class also provides broad member functions for stepping the solution forward in time, computing the non-linear
+    right-hand side, the residual and residual Jacobian for implicit time integration, and other utility functions.
+
+    Args:
+        solver: SystemSolver containing global simulation parameters.
+
+    Attributes:
+        mesh: Mesh object associated with this SolutionDomain.
+        gas_model: GasModel object associated with this SolutionDomain.
+        reaction_model:
+            ReactionModel object associated with this SolutionDomain if a reaction model is requested,
+            None otherwise
+        time_integrator: TimeIntegrator object associated with this SolutionDomain.
+        sol_int: SolutionPhys representing the solution profile of the interior finite volume cells.
+        sol_inlet: SolutionPhys representing the inlet ghost cell.
+        sol_outlet: SolutionPhys representing the outlet ghost cell.
+        invisc_flux_name: String name of the inviscid flux scheme to be applied to this SolutionDomain.
+        invisc_flux_scheme: Flux object corresponding to the inviscid flux scheme associated with this SolutionDomain.
+        sol_ave: SolutionPhys representing the average state at cell faces.
+        visc_flux_name: String name of the flux scheme to be applied to this SolutionDomain.
+        visc_flux_scheme:
+            Flux object corresponding to the viscous flux scheme associated with this SolutionDomain
+            if a viscous scheme is requested, None otherwise.
+        space_order: Order of accuracy of the face reconstruction for computing numerical fluxes.
+        grad_limiter_name:
+            String name of the gradient limiter to be applied to this SolutionDomain, if space_order > 1.
+        grad_limiter:
+            Limiter object associated with this SolutionDomain if a gradient limiter is requested
+            and space_order > 1.
+        sol_left:
+            SolutionPhys representing the solution profile of the reconstructed solution to the left of each face.
+        sol_right:
+            SolutionPhys representing the solution profile of the reconstructed solution to the right of each face.
+        sol_prim_full:
+            NumPy array of primitive solution profile including boundary ghost cell states, to avoid repeated
+            concatenations for gradient calculations.
+        sol_cons_full:
+            NumPy array of conservative solution profile including boundary ghost cell states, to avoid repeated
+            concatenations for gradient calculations.
+        probe_locs: List of spatial coodinates within this SolutionDomain of probe monitors.
+        probe_vars: List of strings of variables to be probed at each probe monitor location.
+        num_probes: Number of probe monitors.
+        num_probe_vars: Number of variables recorded by probe monitors.
+        probe_vals: NumPy array of probe monitor time history for each monitored variable.
+        probe_idxs: List of cell indices within Mesh interior cells where probe monitors are placed.
+        probe_secs:
+            List of strings indicating the SolutionDomain "section"
+            (either "interior", "inlet", or "outlet") where each probe monitor is placed.
+        time_vals: NumPy array of time values associated with each discrete time step, not including t = 0.
+
     """
 
     def __init__(self, solver):
 
         param_dict = solver.param_dict
 
-        # spatial domain
+        # Spatial domain
         mesh_file = str(param_dict["mesh_file"])
         mesh_dict = read_input_file(mesh_file)
         self.mesh = Mesh(mesh_dict)
 
-        # gas model
+        # Gas model
         chem_file = str(param_dict["chem_file"])
         chem_dict = read_input_file(chem_file)
         gas_model_name = catch_input(chem_dict, "gas_model", "cpg")
@@ -56,7 +111,7 @@ class SolutionDomain:
             raise ValueError("Ivalid choice of gas_model: " + gas_model_name)
         gas = self.gas_model
 
-        # reaction model
+        # Reaction model
         reaction_model_name = catch_input(chem_dict, "reaction_model", "none")
         if reaction_model_name == "none":
             assert solver.source_off, "Must provide a valid reaction_model_name if source_off = False"
@@ -69,10 +124,10 @@ class SolutionDomain:
 
             num_reactions = self.reaction_model.num_reactions
 
-        # time integrator
+        # Time integrator
         self.time_integrator = get_time_integrator(solver.time_scheme, param_dict)
 
-        # solution
+        # Solutions
         sol_prim_init = get_initial_conditions(self, solver)
         self.sol_int = SolutionInterior(
             gas, sol_prim_init, solver, self.mesh.num_cells, num_reactions, self.time_integrator
@@ -80,11 +135,11 @@ class SolutionDomain:
         self.sol_inlet = SolutionInlet(gas, solver)
         self.sol_outlet = SolutionOutlet(gas, solver)
 
-        # flux scheme
+        # Flux schemes
         self.invisc_flux_name = catch_input(param_dict, "invisc_flux_scheme", "roe")
         self.visc_flux_name = catch_input(param_dict, "visc_flux_scheme", "invisc")
 
-        # inviscid flux scheme
+        # Inviscid flux scheme
         if self.invisc_flux_name == "roe":
             self.invisc_flux_scheme = RoeInviscFlux(self)
             # TODO: move this to the actual flux class
@@ -93,7 +148,7 @@ class SolutionDomain:
         else:
             raise ValueError("Invalid entry for invisc_flux_name: " + str(self.invisc_flux_name))
 
-        # viscous flux scheme
+        # Viscous flux scheme
         if self.visc_flux_name == "invisc":
             pass
         elif self.visc_flux_name == "standard":
@@ -101,7 +156,7 @@ class SolutionDomain:
         else:
             raise ValueError("Invalid entry for visc_flux_name: " + str(self.visc_flux_name))
 
-        # higher-order reconstructions and gradient limiters
+        # Higher-order reconstructions and gradient limiters
         self.space_order = catch_input(param_dict, "space_order", 1)
         assert self.space_order >= 1, "space_order must be a positive integer"
         if self.space_order > 1:
@@ -116,19 +171,19 @@ class SolutionDomain:
             else:
                 raise ValueError("Invalid entry for grad_limiter_name: " + str(self.grad_limiter_name))
 
-        # for flux calculations
+        # For flux calculations
         ones_prof = np.ones((self.gas_model.num_eqs, self.sol_int.num_cells + 1), dtype=REAL_TYPE)
         self.sol_left = SolutionPhys(gas, self.sol_int.num_cells + 1, sol_prim_in=ones_prof)
         self.sol_right = SolutionPhys(gas, self.sol_int.num_cells + 1, sol_prim_in=ones_prof)
 
-        # to avoid repeated concatenation of ghost cell states
+        # To avoid repeated concatenation of ghost cell states
         self.sol_prim_full = np.zeros(
             (self.gas_model.num_eqs, (self.sol_inlet.num_cells + self.sol_int.num_cells + self.sol_outlet.num_cells)),
             dtype=REAL_TYPE,
         )
         self.sol_cons_full = np.zeros(self.sol_prim_full.shape, dtype=REAL_TYPE)
 
-        # probe storage (as this can include boundaries as well)
+        # Probe storage (as this can include boundaries as well)
         self.probe_locs = catch_list(param_dict, "probe_locs", [None])
         self.probe_vars = catch_list(param_dict, "probe_vars", [None])
         if (self.probe_locs[0] is not None) and (self.probe_vars[0] is not None):
@@ -136,7 +191,7 @@ class SolutionDomain:
             self.num_probe_vars = len(self.probe_vars)
             self.probe_vals = np.zeros((self.num_probes, self.num_probe_vars, solver.num_steps), dtype=REAL_TYPE)
 
-            # get probe locations
+            # Get probe locations
             self.probe_idxs = [None] * self.num_probes
             self.probe_secs = [None] * self.num_probes
             for idx, probe_loc in enumerate(self.probe_locs):
@@ -156,7 +211,7 @@ class SolutionDomain:
         else:
             self.num_probes = 0
 
-        # copy this for use with plotting functions
+        # Copy this for use with plotting functions
         solver.num_probes = self.num_probes
         solver.probe_vars = self.probe_vars
 
@@ -168,39 +223,24 @@ class SolutionDomain:
             dtype=REAL_TYPE,
         )
 
-        # for compatability with hyper-reduction
-        # are overwritten if actually using hyper-reduction
+        # For compatability with hyper-reduction, are overwritten if actually using hyper-reduction
         self.num_samp_cells = self.mesh.num_cells
         self.num_flux_faces = self.mesh.num_cells + 1
         self.num_grad_cells = self.mesh.num_cells
-        # indices of directly sampled cells, within sol_prim/cons
         self.direct_samp_idxs = np.arange(0, self.mesh.num_cells)
-        # indices of "left" cells for flux calcs, within sol_prim/cons_full
         self.flux_samp_left_idxs = np.s_[:-1]
-        # indices of "right" cells for flux calcs, within sol_prim/cons_full
         self.flux_samp_right_idxs = np.s_[1:]
-        # indices of cells for which gradients need to be calculated, within sol_prim/cons_full
         self.grad_idxs = np.arange(1, self.mesh.num_cells + 1)
-        # indices of gradient cells and their immediate neighbors, within sol_prim/cons_full
         self.grad_neigh_idxs = np.s_[:]
-        # indices within gradient neighbor indices to extract gradient cells, excluding boundaries
         self.grad_neigh_extract = np.s_[1:-1]
-        # indices within flux_samp_left_idxs which map to indices of grad_idxs
         self.flux_left_extract = np.s_[1:]
-        # indices within flux_samp_right_idxs which map to indices of grad_idxs
         self.flux_right_extract = np.s_[:-1]
-        # indices within grad_idxs which map to indices of flux_samp_left_idxs
         self.grad_left_extract = np.s_[:]
-        # indices within grad_idxs which map to indices of flux_samp_right_idxs
         self.grad_right_extract = np.s_[:]
-        # indices of flux array which correspond to left face of cell and map to direct_samp_idxs
         self.flux_rhs_idxs = np.arange(0, self.mesh.num_cells)
-
-        # for computing Jacobians
         self.jacob_left_samp = self.flux_rhs_idxs[1:].copy()
         self.jacob_right_samp = self.flux_rhs_idxs[:-1].copy() + 1
 
-        # indices for computing Gamma inverse
         # TODO: remove these once conservative Jacobians are implemented
         self.gamma_idxs = np.s_[:]
         self.gamma_idxs_center = np.s_[:]
@@ -208,9 +248,7 @@ class SolutionDomain:
         self.gamma_idxs_right = np.s_[1:]
 
     def fill_sol_full(self):
-        """
-        Fill sol_prim_full and sol_cons_full from interior and ghost cells
-        """
+        """Fill sol_prim_full and sol_cons_full from interior and ghost cells"""
 
         # TODO: hyper-reduction indices
 
@@ -232,8 +270,12 @@ class SolutionDomain:
         self.sol_cons_full[:, idx_int:] = sol_outlet.sol_cons.copy()
 
     def advance_iter(self, solver):
-        """
-        Advance physical solution forward one time iteration
+        """Advance physical solution forward one physical time iteration.
+
+        Outputs iterations number, and for implicit time integrators, residual norms for iterative convergence.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         if not solver.run_steady:
@@ -243,22 +285,29 @@ class SolutionDomain:
 
             self.advance_subiter(solver)
 
-            # iterative solver convergence
+            # Check iterative solver convergence
             if self.time_integrator.time_type == "implicit":
                 self.sol_int.calc_res_norms(solver, self.time_integrator.subiter)
 
                 if self.sol_int.res_norm_l2 < self.time_integrator.res_tol:
                     break
 
-        # "steady" convergence
+        # Check "steady" convergence
         if solver.run_steady:
             self.sol_int.calc_d_sol_norms(solver, self.time_integrator.time_type)
 
         self.sol_int.update_sol_hist()
 
     def advance_subiter(self, solver):
-        """
-        Advance physical solution forward one subiteration of time integrator
+        """Advance physical solution forward one subiteration of time integrator.
+
+        For implicit time integrator, computes RHS, residual, and residual Jacobian, then computes Newton iteration.
+        Linear solve residual is saved for computing convergence norms later.
+
+        For explicit time integrator, only computes RHS and advances solution explicitly.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         self.calc_rhs(solver)
@@ -274,10 +323,9 @@ class SolutionDomain:
 
             d_sol = spsolve(res_jacob, res.ravel("C"))
 
-            # if solving in dual time, solving for primitive state
+            # If solving in dual time, solving for primitive state
             if self.time_integrator.dual_time:
                 sol_int.sol_prim += d_sol.reshape((gas_model.num_eqs, mesh.num_cells), order="C")
-
             else:
                 sol_int.sol_cons += d_sol.reshape((gas_model.num_eqs, mesh.num_cells), order="C")
 
@@ -285,7 +333,8 @@ class SolutionDomain:
             sol_int.sol_hist_cons[0] = sol_int.sol_cons.copy()
             sol_int.sol_hist_prim[0] = sol_int.sol_prim.copy()
 
-            # use sol_int.res to store linear solve residual
+            # Use sol_int.res to store linear solve residual
+            # TODO: this should be separate for later plotting and output
             res = res_jacob @ d_sol - res.ravel("C")
             sol_int.res = np.reshape(res, (gas_model.num_eqs, mesh.num_cells), order="C")
 
@@ -296,8 +345,13 @@ class SolutionDomain:
             sol_int.update_state(from_cons=True)
 
     def calc_rhs(self, solver):
-        """
-        Compute rhs function
+        """Compute non-linear right-hand side function of spatially-discrete governing ODE.
+
+        Computes boundary ghost cell states, preforms higher-order face reconstructions if requested,
+        computes face fluxes and source term, and stores result in sol_int.rhs.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         sol_int = self.sol_int
@@ -308,7 +362,7 @@ class SolutionDomain:
         samp_idxs = self.direct_samp_idxs
         gas = self.gas_model
 
-        # compute ghost cell state (if adjacent cell is sampled)
+        # Compute ghost cell state (if adjacent cell is sampled)
         # TODO: update this after higher-order contribution?
         # TODO: adapt pass to calc_boundary_state() depending on space scheme
         if samp_idxs[0] == 0:
@@ -320,9 +374,9 @@ class SolutionDomain:
                 solver.sol_time, self.space_order, sol_prim=sol_int.sol_prim[:, -2:], sol_cons=sol_int.sol_cons[:, -2:]
             )
 
-        self.fill_sol_full()  # fill sol_prim_full and sol_cons_full
+        self.fill_sol_full()  # Fill sol_prim_full and sol_cons_full
 
-        # first-order approx at faces
+        # First-order approx at faces
         sol_left = self.sol_left
         sol_right = self.sol_right
         sol_left.sol_prim[:, :] = sol_prim_full[:, self.flux_samp_left_idxs]
@@ -330,8 +384,8 @@ class SolutionDomain:
         sol_right.sol_prim[:, :] = sol_prim_full[:, self.flux_samp_right_idxs]
         sol_right.sol_cons[:, :] = sol_cons_full[:, self.flux_samp_right_idxs]
 
-        # add higher-order contribution
-        # TODO: if not dual_time, reconstruct conservative variables instead of primitive
+        # Add higher-order contribution
+        # TODO: If not dual_time, reconstruct conservative variables instead of primitive
         if self.space_order > 1:
             sol_prim_grad = self.calc_cell_gradients()
             sol_left.sol_prim[:, self.flux_left_extract] += (self.mesh.dx / 2.0) * sol_prim_grad[
@@ -343,16 +397,16 @@ class SolutionDomain:
             sol_left.calc_state_from_prim()
             sol_right.calc_state_from_prim()
 
-        # compute fluxes
+        # Compute fluxes
         flux = self.invisc_flux_scheme.calc_flux(self)
         if self.visc_flux_name != "invisc":
             flux -= self.visc_flux_scheme.calc_flux(self)
 
-        # compute RHS
+        # Compute RHS
         self.sol_int.rhs[:, samp_idxs] = flux[:, self.flux_rhs_idxs] - flux[:, self.flux_rhs_idxs + 1]
         sol_int.rhs[:, samp_idxs] /= self.mesh.dx
 
-        # compute source term
+        # Compute source term
         if not solver.source_off:
             source, wf = self.reaction_model.calc_source(self.sol_int, solver.dt, samp_idxs=samp_idxs)
 
@@ -362,14 +416,16 @@ class SolutionDomain:
             sol_int.rhs[3:, samp_idxs] += sol_int.source[:, samp_idxs]
 
     def calc_cell_gradients(self):
-        """
-        Compute cell-centered gradients for higher-order face reconstructions
+        """Compute cell-centered gradients and gradient limiters for higher-order face reconstructions.
 
-        Also calculate gradient limiters if requested
+        Calculates cell-centered gradients via a finite-difference stencil. If a gradient limiter is requested,
+        the multiplicative limiter factor is computed and the gradient is multiplied by this factor.
+
+        Returns:
+            NumPy array of cell-centered gradients of primitive state profile at all interior cells.
         """
 
-        # TODO: for dual_time = False,
-        # 	should be calculating conservative variable gradients
+        # TODO: for dual_time = False, should be calculating conservative variable gradients
 
         # Compute gradients via finite difference stencil
         sol_prim_grad = np.zeros((self.gas_model.num_eqs, self.num_grad_cells), dtype=REAL_TYPE)
@@ -380,7 +436,7 @@ class SolutionDomain:
         else:
             raise ValueError("Order " + str(self.space_order) + " gradient calculations not implemented")
 
-        # compute gradient limiter and limit gradient, if requested
+        # Compute gradient limiter and limit gradient, if requested
         if self.grad_limiter_name != "none":
             phi = self.grad_limiter.calc_limiter(self, sol_prim_grad)
             sol_prim_grad = sol_prim_grad * phi
@@ -388,21 +444,38 @@ class SolutionDomain:
         return sol_prim_grad
 
     def calc_res_jacob(self, solver):
-        """
-        Compute Jacobian of residual
+        """Compute Jacobian of full-discrete residual.
+
+        Calculates the gradient of the fully-discrete (i.e. after numerical time integration) residual vector
+        with respect to either the full primitive state vector (if dual_time == True) or the full conservative
+        state vector (if dual_time == False). The contributions to the residual Jacobian from the time integrator,
+        flux, and source terms are computed separately and combined.
+        
+        Ultimately, the residual Jacobian can be represented as a block tri-diagonal matrix
+        if the residual vector were flattened in column-major ordering. For the sake of computational efficiency,
+        however, it is later formed into a roughly banded matrix corresponding to the residual vector being flattened
+        in row-major ordering. This final reordering is performed via res_jacob_assemble().
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
+
+        Returns:
+            2D scipy.sparse.csr_matrix of the residual Jacobian, ordered in such a way as to correspond with a
+            row-major flattening of the residual vector (i.e. first by cells, then by variables).
+
         """
 
         sol_int = self.sol_int
         gas = self.gas_model
         samp_idxs = self.gamma_idxs
 
-        # enthalpies
+        # Enthalpies
         sol_int.hi[:, samp_idxs] = gas.calc_spec_enth(sol_int.sol_prim[2, samp_idxs])
         sol_int.h0[samp_idxs] = gas.calc_stag_enth(
             sol_int.sol_prim[1, samp_idxs], sol_int.mass_fracs_full[:, samp_idxs], spec_enth=sol_int.hi[:, samp_idxs],
         )
 
-        # density derivatives
+        # Density derivatives
         (
             sol_int.d_rho_d_press[samp_idxs],
             sol_int.d_rho_d_temp[samp_idxs],
@@ -417,7 +490,7 @@ class SolutionDomain:
             mix_mol_weight=sol_int.mw_mix[samp_idxs],
         )
 
-        # stagnation enthalpy derivatives
+        # Stagnation enthalpy derivatives
         (
             sol_int.d_enth_d_press[samp_idxs],
             sol_int.d_enth_d_temp[samp_idxs],
@@ -507,8 +580,14 @@ class SolutionDomain:
         return res_jacob
 
     def write_iter_outputs(self, solver):
-        """
-        Helper function to save restart files and update probe/snapshot data
+        """Store and save data at time step intervals.
+
+        Write restart files at the time step interval given by solver.restart_interval.
+        Update probe data arrays at every time step.
+        Update snapshot array at interval given by solver.out_interval if not running in "steady" mode.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         # Write restart files
@@ -525,9 +604,17 @@ class SolutionDomain:
                 self.sol_int.update_snapshots(solver)
 
     def write_steady_outputs(self, solver):
-        """
-        Helper function for write "steady" outputs and
-        check "convergence" criterion
+        """Saves "steady" solver outputs and check "convergence" criterion.
+
+        When running in "steady" mode, the solution gets written to disk at the interval given by solver.out_interval.
+        Additionally, the norm of the difference between the current and previous solution is checked to determine
+        whether the "steady" solve has "converged" according to solver.steady_tol.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
+
+        Returns:
+            Boolean flag indicating whether the "steady" solve has "converged". 
         """
 
         # Update convergence and field data file on disk
@@ -543,8 +630,14 @@ class SolutionDomain:
         return break_flag
 
     def write_final_outputs(self, solver):
-        """
-        Helper function to write final field and probe data to disk
+        """Save final field and probe data to disk at end of simulation
+
+        If simulation ran to completion, full field snapshot and probe data are written to disk.
+        If the solver exploded before completing, the field snapshots and and probe data up to that point
+        are written to disk.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         if solver.solve_failed:
@@ -557,14 +650,17 @@ class SolutionDomain:
             self.write_probes(solver)
 
     def update_probes(self, solver):
-        """
-        Update probe storage
+        """Update probe monitor array from current solution.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
         # TODO: throw error for source probe in ghost cells
 
         for probe_iter, probe_idx in enumerate(self.probe_idxs):
 
+            # Determine where the probe monitor is
             probe_sec = self.probe_secs[probe_iter]
             if probe_sec == "inlet":
                 sol_prim_probe = self.sol_inlet.sol_prim[:, 0]
@@ -577,6 +673,7 @@ class SolutionDomain:
                 sol_cons_probe = self.sol_int.sol_cons[:, probe_idx]
                 sol_source_probe = self.sol_int.source[:, probe_idx]
 
+            # Gather probe monitor data
             probe = []
             for var_str in self.probe_vars:
                 if var_str == "pressure":
@@ -604,13 +701,17 @@ class SolutionDomain:
                 else:
                     raise ValueError("Invalid probe variable " + str(var_str))
 
+            # Insert into probe data array
             self.probe_vals[probe_iter, :, solver.iter - 1] = probe
 
     def write_probes(self, solver):
-        """
-        Save probe data to disk
+        """Save probe data to disk at end/failure of simulation.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters. 
         """
 
+        # Get output file name
         probe_file_base_name = "probe"
         for vis_var in self.probe_vars:
             probe_file_base_name += "_" + vis_var

--- a/perform/solution/solution_domain.py
+++ b/perform/solution/solution_domain.py
@@ -48,22 +48,22 @@ class SolutionDomain:
 
         # gas model
         chem_file = str(param_dict["chem_file"])
-        gas_dict = read_input_file(chem_file)
-        gas_model_name = catch_input(gas_dict, "gas_model", "cpg")
+        chem_dict = read_input_file(chem_file)
+        gas_model_name = catch_input(chem_dict, "gas_model", "cpg")
         if gas_model_name == "cpg":
-            self.gas_model = CaloricallyPerfectGas(gas_dict)
+            self.gas_model = CaloricallyPerfectGas(chem_dict)
         else:
             raise ValueError("Ivalid choice of gas_model: " + gas_model_name)
         gas = self.gas_model
 
         # reaction model
-        reaction_model_name = catch_input(gas_dict, "reaction_model", "none")
+        reaction_model_name = catch_input(chem_dict, "reaction_model", "none")
         if reaction_model_name == "none":
             assert solver.source_off, "Must provide a valid reaction_model_name if source_off = False"
             num_reactions = 0
         else:
             if reaction_model_name == "fr_irrev":
-                self.reaction_model = FiniteRateIrrevReaction(gas, gas_dict)
+                self.reaction_model = FiniteRateIrrevReaction(gas, chem_dict)
             else:
                 raise ValueError("Invalid choice of reaction_model: " + reaction_model_name)
 

--- a/perform/solution/solution_interior.py
+++ b/perform/solution/solution_interior.py
@@ -8,11 +8,57 @@ from perform.solution.solution_phys import SolutionPhys
 
 
 class SolutionInterior(SolutionPhys):
-    """
-    Solution of interior domain
+    """Physical solution of interior cells.
+
+    This SolutionPhys represents the interior finite volume cells of a SolutionDomain,
+    i.e. all cells except the boundary ghost cells. There is only one SolutionInterior per SolutionDomain.
+    
+    A few constructs, such as the source term, residual, residual Jacobian, etc., are only meaningful for the interior
+    cells and so are represented here specifically.
+
+    Additionally, this class provides member methods which handle the output of snapshot matrices and residual norms,
+    as there are also only meaningful for the interior cells.
+
+    Args:
+        gas: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
+        sol_prim_in: NumPy array of the primitive state profiles that this SolutionPhys represents.
+        solver: SystemSolver containing global simulation parameters. 
+        num_cells: Number of finite volume cells represented by this SolutionPhys.
+        num_reactions: Number of reactions to be modeled.
+        time_int: TimeIntegrator associated with the SolutionDomain with which this SolutionInterior is associated.
+
+    Attributes:
+        wf:
+            NumPy array of the rate-of-progress profiles for the num_reactions reactions,
+            if modeling reactions by a finite-rate reaction model.
+        source: NumPy array of the reaction source term profiles for the num_species species transport equations.
+        rhs: NumPy array of the evaluation of the right-hand side function of the semi-discrete governing ODE.
+        sol_hist_cons: List of NumPy arrays of the prior time_int.time_order conservative state profiles.
+        sol_hist_prim: List of NumPy arrays of the prior time_int.time_order primitive state profiles.
+        rhs_hist: List of NumPy arrays of the prior time_int.time_order RHS function profiles.
+        prim_snap: NumPy array of the primitive state snapshot array to be written to disk.
+        cons_snap: NumPy array of the conservative state snapshot array to be written to disk.
+        source_snap: NumPy array of the source term snapshot array to be written to disk.
+        rhs_snap: NumPy array of the RHS function snapshot array to be written to disk.
+        res: NumPy array of the full-discrete residual function profile.
+        res_norm_l2: L2 norm of the Newton iteration linear solve residual, normalized.
+        res_norm_l1: L1 norm of the Newton iteration linear solve residual, normalized.
+        res_norm_hist: NumPy array of the time history of the L2 and L1 linear solver residual norm.
+        jacob_dim_first: Leading dimension of the residual Jacobian.
+        jacob_dim_second: Trailing dimension of the residual Jacobian.
+        jacob_row_idxs:
+            NumPy array of row indices within the 2D residual Jacobian at which the
+            flattened 3D residual Jacobian will be emplaced.
+        jacob_col_idxs:
+            NumPy array of column indices within the 2D residual Jacobian at which the
+            flattened 3D residual Jacobian will be emplaced.
+        d_sol_norm_l2: L2 norm of the primitive solution change, normalized.
+        d_sol_norm_l1: L1 norm of the primitive solution change, normalized.
+        d_sol_norm_hist: NumPy array of the time history of the L2 and L1 primitive solution change norm.
     """
 
     def __init__(self, gas, sol_prim_in, solver, num_cells, num_reactions, time_int):
+        
         super().__init__(gas, num_cells, sol_prim_in=sol_prim_in)
 
         gas = self.gas_model
@@ -22,19 +68,19 @@ class SolutionInterior(SolutionPhys):
         self.source = np.zeros((gas.num_species, num_cells), dtype=REAL_TYPE)
         self.rhs = np.zeros((gas.num_eqs, num_cells), dtype=REAL_TYPE)
 
-        # add bulk velocity and update state if requested
+        # Add bulk velocity and update state if requested
         if solver.vel_add != 0.0:
             self.sol_prim[1, :] += solver.vel_add
             self.update_state(from_cons=False)
 
-        # initializing time history
+        # Initializing time history
         self.sol_hist_cons = [self.sol_cons.copy()] * (time_int.time_order + 1)
         self.sol_hist_prim = [self.sol_prim.copy()] * (time_int.time_order + 1)
 
         # RHS storage for multi-stage schemes
         self.rhs_hist = [self.rhs.copy()] * (time_int.time_order + 1)
 
-        # snapshot storage matrices, store initial condition
+        # Snapshot storage matrices, store initial condition
         if solver.prim_out:
             self.prim_snap = np.zeros((gas.num_eqs, num_cells, solver.num_snaps + 1), dtype=REAL_TYPE)
             self.prim_snap[:, :, 0] = self.sol_prim.copy()
@@ -42,17 +88,14 @@ class SolutionInterior(SolutionPhys):
             self.cons_snap = np.zeros((gas.num_eqs, num_cells, solver.num_snaps + 1), dtype=REAL_TYPE)
             self.cons_snap[:, :, 0] = self.sol_cons.copy()
 
-        # these don't include the source/RHS associated with the final solution
-        # TODO: calculate at final solution for DEIM stuff
+        # These don't include the source/RHS associated with the final solution
         if solver.source_out:
             self.source_snap = np.zeros((gas.num_species, num_cells, solver.num_snaps), dtype=REAL_TYPE)
         if solver.rhs_out:
             self.rhs_snap = np.zeros((gas.num_eqs, num_cells, solver.num_snaps), dtype=REAL_TYPE)
 
         if (time_int.time_type == "implicit") or (solver.run_steady):
-            # norm normalization constants
-            # TODO: will need a normalization constant for
-            # 	conservative residual when it's implemented
+            # Norm normalization constants
             if (len(solver.res_norm_prim) == 1) and (solver.res_norm_prim[0] is None):
                 solver.res_norm_prim = [None] * gas.num_eqs
             else:
@@ -62,13 +105,13 @@ class SolutionInterior(SolutionPhys):
                     # 0: pressure, 1: velocity, 2: temperature, >=3: species
                     solver.res_norm_prim[var_idx] = RES_NORM_PRIM_DEFAULT[min(var_idx, 3)]
 
-            # residual norm storage
+            # Residual norm storage
             if time_int.time_type == "implicit":
 
                 self.res = np.zeros((gas.num_eqs, num_cells), dtype=REAL_TYPE)
                 self.res_norm_l2 = 0.0
                 self.res_norm_l1 = 0.0
-                self.res_norm_history = np.zeros((solver.num_steps, 2), dtype=REAL_TYPE)
+                self.res_norm_hist = np.zeros((solver.num_steps, 2), dtype=REAL_TYPE)
 
                 if (time_int.dual_time) and (time_int.adapt_dtau):
                     self.srf = np.zeros(num_cells, dtype=REAL_TYPE)
@@ -110,17 +153,32 @@ class SolutionInterior(SolutionPhys):
                 self.jacob_row_idxs = np.concatenate((row_idxs_center, row_idxs_lower, row_idxs_upper))
                 self.jacob_col_idxs = np.concatenate((col_idxs_center, col_idxs_lower, col_idxs_upper))
 
-            # "steady" convergence measures
+            # "Steady" convergence measures
             if solver.run_steady:
                 self.d_sol_norm_l2 = 0.0
                 self.d_sol_norm_l1 = 0.0
-                self.d_sol_norm_history = np.zeros((solver.num_steps, 2), dtype=REAL_TYPE)
+                self.d_sol_norm_hist = np.zeros((solver.num_steps, 2), dtype=REAL_TYPE)
 
     def calc_d_sol_prim_d_sol_cons(self, samp_idxs=np.s_[:]):
-        """
-        Compute the Jacobian of the conservative state w/r/t/ the primitive state
+        """Compute the Jacobian of the primitive state w/r/t/ the conservative state
 
-        This appears as Gamma^{-1} in the PERFORM documentation
+        This Jacobian is calculated when computing the approximate residual Jacobian w/r/t the conservative
+        state when dual_time == False. It is also implicitly used when calculating the Roe dissipation term,
+        but is not explicitly calculated there.
+        
+        Assumes that the stagnation enthalpy, derivatives of density,
+        and derivatives of stagnation enthalpy have already been computed.
+
+        This appears as Gamma^{-1} in the solver theory documentation, please refer to the solver theory documentation
+        for a detailed derivation of this matrix.
+
+        Args:
+            samp_idxs: 
+                Either a NumPy slice or NumPy array for selecting sampled cells to compute the Jacobian at.
+                Used for hyper-reduction of projection-based reduced-order models.
+
+        Returns:
+            3D NumPy array of the Jacobian of the primitive state w/r/t the conservative state.
         """
 
         # TODO: some repeated calculations
@@ -128,14 +186,14 @@ class SolutionInterior(SolutionPhys):
 
         gas = self.gas_model
 
-        # initialize Jacobian
+        # Initialize Jacobian
         if type(samp_idxs) is slice:
             num_cells = sol_int.num_cells
         else:
             num_cells = samp_idxs.shape[0]
         gamma_matrix_inv = np.zeros((gas.num_eqs, gas.num_eqs, num_cells))
 
-        # for clarity
+        # For clarity
         rho = self.sol_cons[0, samp_idxs]
         press = self.sol_prim[0, samp_idxs]
         vel = self.sol_prim[1, samp_idxs]
@@ -150,11 +208,11 @@ class SolutionInterior(SolutionPhys):
         d_enth_d_mass_frac = self.d_enth_d_mass_frac[:, samp_idxs]
         h0 = self.h0[samp_idxs]
 
-        # some reused terms
+        # Some reused terms
         d = rho * d_rho_d_press * d_enth_d_temp - d_rho_d_temp * (rho * d_enth_d_press - 1.0)
         vel_sq = np.square(vel)
 
-        # density row
+        # Density row
         gamma_matrix_inv[0, 0, :] = (
             rho * d_enth_d_temp
             + d_rho_d_temp * (h0 - vel_sq)
@@ -169,11 +227,11 @@ class SolutionInterior(SolutionPhys):
             d_rho_d_temp[None, :] * d_enth_d_mass_frac - d_rho_d_mass_frac * d_enth_d_temp[None, :]
         ) / d[None, :]
 
-        # momentum row
+        # Momentum row
         gamma_matrix_inv[1, 0, :] = -vel / rho
         gamma_matrix_inv[1, 1, :] = 1.0 / rho
 
-        # energy row
+        # Energy row
         gamma_matrix_inv[2, 0, :] = (
             -d_rho_d_press * (h0 - vel_sq)
             - (rho * d_enth_d_press - 1.0)
@@ -197,7 +255,7 @@ class SolutionInterior(SolutionPhys):
             / (rho * d)[None, :]
         )
 
-        # species row(s)
+        # Species row(s)
         gamma_matrix_inv[3:, 0, :] = -mass_fracs / rho[None, :]
         for i in range(3, gas.num_eqs):
             gamma_matrix_inv[i, i, :] = 1.0 / rho
@@ -205,24 +263,38 @@ class SolutionInterior(SolutionPhys):
         return gamma_matrix_inv
 
     def calc_d_sol_cons_d_sol_prim(self, samp_idxs=np.s_[:]):
-        """
-        Compute the Jacobian of conservative state w/r/t the primitive state
+        """Compute the Jacobian of the conservative state w/r/t/ the primitive state
 
-        This appears as Gamma in the PERFORM documentation
+        This Jacobian is calculated when computing the residual Jacobian w/r/t the primitive
+        state when dual_time == True.
+        
+        Assumes that the stagnation enthalpy, derivatives of density,
+        and derivatives of stagnation enthalpy have already been computed.
+
+        This appears as Gamma in the solver theory documentation, please refer to
+        the solver theory documentation for a detailed derivation of this matrix.
+
+        Args:
+            samp_idxs: 
+                Either a NumPy slice or NumPy array for selecting sampled cells to compute the Jacobian at.
+                Used for hyper-reduction of projection-based reduced-order models.
+
+        Returns:
+            3D NumPy array of the Jacobian of the conservative state w/r/t the primitive state.
         """
 
         # TODO: add option for preconditioning d_rho_d_press
 
         gas = self.gas_model
 
-        # initialize Jacobian
+        # Initialize Jacobian
         if type(samp_idxs) is slice:
             num_cells = sol_int.num_cells
         else:
             num_cells = samp_idxs.shape[0]
         gamma_matrix = np.zeros((gas.num_eqs, gas.num_eqs, num_cells))
 
-        # for clarity
+        # For clarity
         rho = self.sol_cons[0, samp_idxs]
         press = self.sol_prim[0, samp_idxs]
         vel = self.sol_prim[1, samp_idxs]
@@ -237,24 +309,24 @@ class SolutionInterior(SolutionPhys):
         d_enth_d_mass_frac = self.d_enth_d_mass_frac[:, samp_idxs]
         h0 = self.h0[samp_idxs]
 
-        # density row
+        # Density row
         gamma_matrix[0, 0, :] = d_rho_d_press
         gamma_matrix[0, 2, :] = d_rho_d_temp
         gamma_matrix[0, 3:, :] = d_rho_d_mass_frac
 
-        # momentum row
+        # Momentum row
         gamma_matrix[1, 0, :] = vel * d_rho_d_press
         gamma_matrix[1, 1, :] = rho
         gamma_matrix[1, 2, :] = vel * d_rho_d_temp
         gamma_matrix[1, 3:, :] = vel[None, :] * d_rho_d_mass_frac
 
-        # total energy row
+        # Total energy row
         gamma_matrix[2, 0, :] = d_rho_d_press * h0 + rho * d_enth_d_press - 1.0
         gamma_matrix[2, 1, :] = rho * vel
         gamma_matrix[2, 2, :] = d_rho_d_temp * h0 + rho * d_enth_d_temp
         gamma_matrix[2, 3:, :] = h0[None, :] * d_rho_d_mass_frac + rho[None, :] * d_enth_d_mass_frac
 
-        # species row
+        # Species row
         gamma_matrix[3:, 0, :] = mass_fracs[gas.mass_frac_slice, :] * d_rho_d_press[None, :]
         gamma_matrix[3:, 2, :] = mass_fracs[gas.mass_frac_slice, :] * d_rho_d_temp[None, :]
         for i in range(3, gas.num_eqs):
@@ -264,8 +336,26 @@ class SolutionInterior(SolutionPhys):
         return gamma_matrix
 
     def res_jacob_assemble(self, center_block, lower_block, upper_block):
-        """
-        Reassemble residual Jacobian into a sparse 2D array for linear solve
+        """Assembles residual Jacobian into a sparse 2D matrix for Newton's method linear solve.
+
+        The components of the residual Jacobian are provided as 3D arrays representing the center, lower, 
+        and upper block diagonal of the residual Jacobian if the residual were flattened in column-major
+        order (i.e. variables first, then cells). This makes populating the components easier, but makes 
+        calculating the linear solve more tedious. Thus, the residual Jacobian is constructed for a residual
+        flattened in row-major order (i.e. cells first, then variables).
+
+        Note that the returned Jacobian is a scipy.sparse matrix; care must be taken when performing math operations
+        with this as the resulting object may devolve to a NumPy matrix, which is deprecated. If this problem
+        cannot be avoided, use .toarray() to convert the sparse matrix to a NumPy array. This is not ideal as it
+        generates a large dense matrix.
+
+        Args:
+            center_block: 3D NumPy array of the center block diagonal of column-major residual Jacobian.
+            lower_block: 3D NumPy array of the lower block diagonal of column-major residual Jacobian.
+            upper_block: 3D NumPy array of the upper block diagonal of column-major residual Jacobian.
+
+        Returns:
+            scipy.sparse.csr_matrix of row-major residual Jacobian.
         """
 
         # TODO: my God, this is still the single most expensive operation
@@ -282,17 +372,25 @@ class SolutionInterior(SolutionPhys):
         return res_jacob
 
     def calc_adaptive_dtau(self, mesh):
-        """
-        Adapt dtau for each cell based on user input constraints and local wave speed
+        """Adapt dtau for each cell based on user input constraints and local wave speed.
+        
+        This function is intended to improve dual time-stepping robustness, but mostly acts to slow convergence.
+        For now, I recommend not setting adapt_dtau until this is completed.
+        
+        Args:
+            mesh: Mesh associated with SolutionDomain with which this SolutionPhys is associated.
+
+        Returns:
+            Reciprocal of adapted dtau profile.
         """
 
         gas_model = self.gas_model
 
-        # compute initial dtau from input cfl and srf
+        # Compute initial dtau from input cfl and srf
         dtaum = 1.0 * mesh.dx / self.srf
         dtau = self.time_integrator.cfl * dtaum
 
-        # limit by von Neumann number
+        # Limit by von Neumann number
         if self.visc_flux_name != "invisc":
             # TODO: calculating this is stupidly expensive
             self.dyn_visc_mix = gas_model.calc_mix_dynamic_visc(
@@ -302,29 +400,37 @@ class SolutionInterior(SolutionPhys):
             dtau = np.minimum(dtau, self.time_integrator.vnn * np.square(mesh.dx) / nu)
             dtaum = np.minimum(dtaum, 3.0 / nu)
 
-        # limit dtau
-        # TODO: implement solutionChangeLimitedTimeStep from gems_precon.f90
+        # Limit dtau
+        # TODO: finish implementation
 
         return 1.0 / dtau
 
     def update_sol_hist(self):
-        """
-        Update time history of solution and RHS function for multi-stage time integrators
+        """Update time history of solution and RHS function for multi-stage time integrators.
+
+        After each physical time iteration, the primitive solution, conservative solution, and RHS profile
+        histories are pushed back by one and the first entry is replaced by the current time step's profiles.
         """
 
-        # primitive and conservative state history
+        # Primitive and conservative state history
         self.sol_hist_cons[1:] = self.sol_hist_cons[:-1]
         self.sol_hist_prim[1:] = self.sol_hist_prim[:-1]
         self.sol_hist_cons[0] = self.sol_cons.copy()
         self.sol_hist_prim[0] = self.sol_prim.copy()
 
-        # TODO: RHS update should occur at the FIRST subiteration
-        # 	right after the RHS is calculated
         # RHS function history
         self.rhs_hist[1:] = self.rhs_hist[:-1]
         self.rhs_hist[0] = self.rhs.copy()
 
     def update_snapshots(self, solver):
+        """Update snapshot arrays.
+
+        Adds current solution, source, RHS, etc. profiles to snapshots arrays.
+        At the end of a simulation (completed or failed), these will be written to disk.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters.
+        """
 
         store_idx = int((solver.iter - 1) / solver.out_interval) + 1
 
@@ -338,13 +444,16 @@ class SolutionInterior(SolutionPhys):
             self.rhs_snap[:, :, store_idx - 1] = self.rhs
 
     def write_snapshots(self, solver, failed):
-        """
-        Save snapshot matrices to disk
+        """Save snapshot matrices to disk after completed/failed simulation.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters.
+            failed: Boolean flag indicating whether a simulation has failed before completion.
         """
 
         unsteady_output_dir = solver.unsteady_output_dir
 
-        # account for failed simulation dump
+        # Account for failed simulation dump
         # TODO: need to account for non-unity out_interval
         if failed:
             offset = 1
@@ -369,19 +478,19 @@ class SolutionInterior(SolutionPhys):
             np.save(sol_rhs_file, self.rhs_snap[:, :, : final_idx - 1])
 
     def write_restart_file(self, solver):
-        """
-        Write restart files containing primitive and conservative fields,
-        and associated physical time
+        """Write restart files to disk.
+        
+        Restart files contain the primitive and conservative fields current associated physical time.
+        
+        Args:
+            solver: SystemSolver containing global simulation parameters.
         """
 
-        # TODO: write previous time step(s) for multi-step methods
-        # 	to preserve time accuracy at restart
-
-        # write restart file to zipped file
+        # Write restart file to zipped file
         restart_file = os.path.join(solver.restart_output_dir, "restart_file_" + str(solver.restart_iter) + ".npz")
         np.savez(restart_file, sol_time=solver.sol_time, sol_prim=self.sol_prim, sol_cons=self.sol_cons)
 
-        # write iteration number files
+        # Write iteration number files
         restartIterFile = os.path.join(solver.restart_output_dir, "restart_iter.dat")
         with open(restartIterFile, "w") as f:
             f.write(str(solver.restart_iter) + "\n")
@@ -392,15 +501,23 @@ class SolutionInterior(SolutionPhys):
         with open(restart_phys_iter_file, "w") as f:
             f.write(str(solver.iter) + "\n")
 
-        # iterate file count
+        # Iterate file count
         if solver.restart_iter < solver.num_restarts:
             solver.restart_iter += 1
         else:
             solver.restart_iter = 1
 
     def write_steady_data(self, solver):
+        """Write "steady" solve "convergence" norms and current solution profiles to disk.
 
-        # write norm data to ASCII file
+        The "convergence" norms file provides a history of the steady solve convergence at each iteration,
+        while the primitive and conservative solution file are continuously overwritten with the most recent solution.
+
+        Args:
+            solver: SystemSolver containing global simulation parameters.
+        """
+
+        # Write norm data to ASCII file
         steady_file = os.path.join(solver.unsteady_output_dir, "steady_convergence.dat")
         if solver.iter == 1:
             f = open(steady_file, "w")
@@ -410,63 +527,25 @@ class SolutionInterior(SolutionPhys):
         f.write(out_string)
         f.close()
 
-        # write field data
+        # Write field data
         sol_prim_file = os.path.join(solver.unsteady_output_dir, "sol_prim_steady.npy")
         np.save(sol_prim_file, self.sol_prim)
 
         sol_cons_file = os.path.join(solver.unsteady_output_dir, "sol_cons_steady.npy")
         np.save(sol_cons_file, self.sol_cons)
 
-    def calc_d_sol_norms(self, solver, time_type):
-        """
-        Calculate and print solution change norms
-        Note that output is ORDER OF MAGNITUDE of residual norm
-        (i.e. 1e-X, where X is the order of magnitude)
-        """
-
-        if time_type == "implicit":
-            d_sol = self.sol_hist_prim[0] - self.sol_hist_prim[1]
-        else:
-            # TODO: only valid for single-stage explicit schemes
-            d_sol = self.sol_prim - self.sol_hist_prim[0]
-
-        norm_l2, norm_l1 = self.calc_norms(d_sol, solver.res_norm_prim)
-
-        norm_out_l2 = np.log10(norm_l2)
-        norm_out_l1 = np.log10(norm_l1)
-        out_string = ("%8i:   L2: %18.14f,   L1: %18.14f") % (solver.time_iter, norm_out_l2, norm_out_l1)
-        print(out_string)
-
-        self.d_sol_norm_l2 = norm_l2
-        self.d_sol_norm_l1 = norm_l1
-        self.d_sol_norm_history[solver.iter - 1, :] = [norm_l2, norm_l1]
-
-    def calc_res_norms(self, solver, subiter):
-        """
-        Calculate and print linear solve residual norms
-
-        Note that output is ORDER OF MAGNITUDE of residual norm (i.e. 1e-X, where X is the order of magnitude)
-        """
-
-        # TODO: pass conservative norm factors if running cons implicit solve
-        norm_l2, norm_l1 = self.calc_norms(self.res, solver.res_norm_prim)
-
-        # don't print for "steady" solve
-        if not solver.run_steady:
-            norm_out_l2 = np.log10(norm_l2)
-            norm_out_l1 = np.log10(norm_l1)
-            out_string = (str(subiter + 1) + ":\tL2: %18.14f, \tL1: %18.14f") % (norm_out_l2, norm_out_l1)
-            print(out_string)
-
-        self.res_norm_l2 = norm_l2
-        self.res_norm_l1 = norm_l1
-        self.res_norm_history[solver.iter - 1, :] = [norm_l2, norm_l1]
-
     def calc_norms(self, arr_in, norm_facs):
-        """
-        Compute L1 and L2 norms of arr_in
+        """Compute average, normalized L1 and L2 norms of an array.
 
-        arr_in assumed to be in [numVars, num_cells] order
+        In reality, this computes the RMS measure as it is divided by the square root of the number of elements.
+        arr_in assumed to be in [num_vars, num_cells] order, as is the case for, e.g., sol_prim and sol_cons.
+
+        Args:
+            arr_in: NumPy array for which norms are to be calculated.
+            norm_facs: NumPy array of factors by which to normalize each profile in arr_in before computing norms.
+
+        Returns:
+            Average, normalized L2 and L1 norms of arr_in.
         """
 
         arr_abs = np.abs(arr_in)
@@ -485,3 +564,60 @@ class SolutionInterior(SolutionPhys):
         arr_norm_l1 = np.mean(arr_norm_l1)
 
         return arr_norm_l2, arr_norm_l1
+
+    def calc_d_sol_norms(self, solver, time_type):
+        """Calculate and print solution change norms for "steady" solve "convergence".
+        
+        Computes L2 and L1 norms of the change in the primitive solution between time steps.
+        This measure will be used to determine whether the "steady" solve has "converged".
+        
+        Note that outputs are orders of magnitude (i.e. 1e-X, where X is the order of magnitude)
+
+        Args:
+            solver: SystemSolver containing global simulation parameters.
+            time_type: Either "explicit" or "implicit", affects how solution profiles are retrieved.
+        """
+
+        # Calculate solution change and its norms
+        if time_type == "implicit":
+            d_sol = self.sol_hist_prim[0] - self.sol_hist_prim[1]
+        else:
+            d_sol = self.sol_prim - self.sol_hist_prim[0]
+
+        norm_l2, norm_l1 = self.calc_norms(d_sol, solver.res_norm_prim)
+
+        # Print to terminal
+        norm_out_l2 = np.log10(norm_l2)
+        norm_out_l1 = np.log10(norm_l1)
+        out_string = ("%8i:   L2: %18.14f,   L1: %18.14f") % (solver.time_iter, norm_out_l2, norm_out_l1)
+        print(out_string)
+
+        self.d_sol_norm_l2 = norm_l2
+        self.d_sol_norm_l1 = norm_l1
+        self.d_sol_norm_hist[solver.iter - 1, :] = [norm_l2, norm_l1]
+
+    def calc_res_norms(self, solver, subiter):
+        """Calculate and print implicit time integration linear solve residual norms.
+        
+        Computes L2 and L1 norms of the Newton's method iterative solve for implicit time integration.
+        This measure will be used to determine whether Newton's method has converged.
+        
+        Note that outputs are orders of magnitude (i.e. 1e-X, where X is the order of magnitude)
+
+        Args:
+            solver: SystemSolver containing global simulation parameters.
+            subiter: Time step subiteration number, for terminal output.
+        """
+
+        norm_l2, norm_l1 = self.calc_norms(self.res, solver.res_norm_prim)
+
+        # Don't print for "steady" solve
+        if not solver.run_steady:
+            norm_out_l2 = np.log10(norm_l2)
+            norm_out_l1 = np.log10(norm_l1)
+            out_string = (str(subiter + 1) + ":\tL2: %18.14f, \tL1: %18.14f") % (norm_out_l2, norm_out_l1)
+            print(out_string)
+
+        self.res_norm_l2 = norm_l2
+        self.res_norm_l1 = norm_l1
+        self.res_norm_hist[solver.iter - 1, :] = [norm_l2, norm_l1]

--- a/perform/solution/solution_interior.py
+++ b/perform/solution/solution_interior.py
@@ -58,7 +58,7 @@ class SolutionInterior(SolutionPhys):
     """
 
     def __init__(self, gas, sol_prim_in, solver, num_cells, num_reactions, time_int):
-        
+
         super().__init__(gas, num_cells, sol_prim_in=sol_prim_in)
 
         gas = self.gas_model

--- a/perform/solution/solution_interior.py
+++ b/perform/solution/solution_interior.py
@@ -12,7 +12,7 @@ class SolutionInterior(SolutionPhys):
 
     This SolutionPhys represents the interior finite volume cells of a SolutionDomain,
     i.e. all cells except the boundary ghost cells. There is only one SolutionInterior per SolutionDomain.
-    
+
     A few constructs, such as the source term, residual, residual Jacobian, etc., are only meaningful for the interior
     cells and so are represented here specifically.
 
@@ -22,7 +22,7 @@ class SolutionInterior(SolutionPhys):
     Args:
         gas: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
         sol_prim_in: NumPy array of the primitive state profiles that this SolutionPhys represents.
-        solver: SystemSolver containing global simulation parameters. 
+        solver: SystemSolver containing global simulation parameters.
         num_cells: Number of finite volume cells represented by this SolutionPhys.
         num_reactions: Number of reactions to be modeled.
         time_int: TimeIntegrator associated with the SolutionDomain with which this SolutionInterior is associated.
@@ -165,7 +165,7 @@ class SolutionInterior(SolutionPhys):
         This Jacobian is calculated when computing the approximate residual Jacobian w/r/t the conservative
         state when dual_time == False. It is also implicitly used when calculating the Roe dissipation term,
         but is not explicitly calculated there.
-        
+
         Assumes that the stagnation enthalpy, derivatives of density,
         and derivatives of stagnation enthalpy have already been computed.
 
@@ -173,7 +173,7 @@ class SolutionInterior(SolutionPhys):
         for a detailed derivation of this matrix.
 
         Args:
-            samp_idxs: 
+            samp_idxs:
                 Either a NumPy slice or NumPy array for selecting sampled cells to compute the Jacobian at.
                 Used for hyper-reduction of projection-based reduced-order models.
 
@@ -188,16 +188,14 @@ class SolutionInterior(SolutionPhys):
 
         # Initialize Jacobian
         if type(samp_idxs) is slice:
-            num_cells = sol_int.num_cells
+            num_cells = self.num_cells
         else:
             num_cells = samp_idxs.shape[0]
         gamma_matrix_inv = np.zeros((gas.num_eqs, gas.num_eqs, num_cells))
 
         # For clarity
         rho = self.sol_cons[0, samp_idxs]
-        press = self.sol_prim[0, samp_idxs]
         vel = self.sol_prim[1, samp_idxs]
-        temp = self.sol_prim[2, samp_idxs]
         mass_fracs = self.sol_prim[3:, samp_idxs]
 
         d_rho_d_press = self.d_rho_d_press[samp_idxs]
@@ -267,7 +265,7 @@ class SolutionInterior(SolutionPhys):
 
         This Jacobian is calculated when computing the residual Jacobian w/r/t the primitive
         state when dual_time == True.
-        
+
         Assumes that the stagnation enthalpy, derivatives of density,
         and derivatives of stagnation enthalpy have already been computed.
 
@@ -275,7 +273,7 @@ class SolutionInterior(SolutionPhys):
         the solver theory documentation for a detailed derivation of this matrix.
 
         Args:
-            samp_idxs: 
+            samp_idxs:
                 Either a NumPy slice or NumPy array for selecting sampled cells to compute the Jacobian at.
                 Used for hyper-reduction of projection-based reduced-order models.
 
@@ -289,16 +287,14 @@ class SolutionInterior(SolutionPhys):
 
         # Initialize Jacobian
         if type(samp_idxs) is slice:
-            num_cells = sol_int.num_cells
+            num_cells = self.num_cells
         else:
             num_cells = samp_idxs.shape[0]
         gamma_matrix = np.zeros((gas.num_eqs, gas.num_eqs, num_cells))
 
         # For clarity
         rho = self.sol_cons[0, samp_idxs]
-        press = self.sol_prim[0, samp_idxs]
         vel = self.sol_prim[1, samp_idxs]
-        temp = self.sol_prim[2, samp_idxs]
         mass_fracs = self.sol_prim[3:, samp_idxs]
 
         d_rho_d_press = self.d_rho_d_press[samp_idxs]
@@ -338,9 +334,9 @@ class SolutionInterior(SolutionPhys):
     def res_jacob_assemble(self, center_block, lower_block, upper_block):
         """Assembles residual Jacobian into a sparse 2D matrix for Newton's method linear solve.
 
-        The components of the residual Jacobian are provided as 3D arrays representing the center, lower, 
+        The components of the residual Jacobian are provided as 3D arrays representing the center, lower,
         and upper block diagonal of the residual Jacobian if the residual were flattened in column-major
-        order (i.e. variables first, then cells). This makes populating the components easier, but makes 
+        order (i.e. variables first, then cells). This makes populating the components easier, but makes
         calculating the linear solve more tedious. Thus, the residual Jacobian is constructed for a residual
         flattened in row-major order (i.e. cells first, then variables).
 
@@ -373,10 +369,10 @@ class SolutionInterior(SolutionPhys):
 
     def calc_adaptive_dtau(self, mesh):
         """Adapt dtau for each cell based on user input constraints and local wave speed.
-        
+
         This function is intended to improve dual time-stepping robustness, but mostly acts to slow convergence.
         For now, I recommend not setting adapt_dtau until this is completed.
-        
+
         Args:
             mesh: Mesh associated with SolutionDomain with which this SolutionPhys is associated.
 
@@ -479,9 +475,9 @@ class SolutionInterior(SolutionPhys):
 
     def write_restart_file(self, solver):
         """Write restart files to disk.
-        
+
         Restart files contain the primitive and conservative fields current associated physical time.
-        
+
         Args:
             solver: SystemSolver containing global simulation parameters.
         """
@@ -567,10 +563,10 @@ class SolutionInterior(SolutionPhys):
 
     def calc_d_sol_norms(self, solver, time_type):
         """Calculate and print solution change norms for "steady" solve "convergence".
-        
+
         Computes L2 and L1 norms of the change in the primitive solution between time steps.
         This measure will be used to determine whether the "steady" solve has "converged".
-        
+
         Note that outputs are orders of magnitude (i.e. 1e-X, where X is the order of magnitude)
 
         Args:
@@ -598,10 +594,10 @@ class SolutionInterior(SolutionPhys):
 
     def calc_res_norms(self, solver, subiter):
         """Calculate and print implicit time integration linear solve residual norms.
-        
+
         Computes L2 and L1 norms of the Newton's method iterative solve for implicit time integration.
         This measure will be used to determine whether Newton's method has converged.
-        
+
         Note that outputs are orders of magnitude (i.e. 1e-X, where X is the order of magnitude)
 
         Args:

--- a/perform/solution/solution_phys.py
+++ b/perform/solution/solution_phys.py
@@ -98,8 +98,8 @@ class SolutionPhys:
         """Utility function to update primitive state from conservative state or vice versa.
 
         Args:
-            from_cons: 
-                If True, update primitive state from conservative state. 
+            from_cons:
+                If True, update primitive state from conservative state.
                 If False, update conservative state from primitive state.
         """
 

--- a/perform/solution/solution_phys.py
+++ b/perform/solution/solution_phys.py
@@ -79,7 +79,7 @@ class SolutionPhys:
 
         # mass fractions
         self.sol_prim[3:, :] = self.sol_cons[3:, :] / self.sol_cons[[0], :]
-        mass_fracs = self.gas_model.get_mass_frac_array(sol_prim=self.sol_prim)
+        mass_fracs = self.gas_model.get_mass_frac_array(sol_prim_in=self.sol_prim)
         mass_fracs = self.gas_model.calc_all_mass_fracs(mass_fracs, threshold=True)
         self.mass_fracs_full[:, :] = mass_fracs.copy()
         if self.gas_model.num_species_full > 1:
@@ -110,7 +110,7 @@ class SolutionPhys:
         # 	species enthalpies
 
         # mass fractions
-        mass_fracs = self.gas_model.get_mass_frac_array(sol_prim=self.sol_prim)
+        mass_fracs = self.gas_model.get_mass_frac_array(sol_prim_in=self.sol_prim)
         mass_fracs = self.gas_model.calc_all_mass_fracs(mass_fracs, threshold=True)
         self.mass_fracs_full[:, :] = mass_fracs.copy()
         if self.gas_model.num_species_full > 1:

--- a/perform/solution/solution_phys.py
+++ b/perform/solution/solution_phys.py
@@ -4,8 +4,44 @@ from perform.constants import REAL_TYPE, HUGE_NUM
 
 
 class SolutionPhys:
-    """
-    Base class for physical solution (opposed to ROM solution)
+    """Base class for full-dimensional physical solution.
+
+    This class provides the attributes and member functions required for describing a discrete system solution,
+    including transport properties, thermodynamic properties, and derivative thereof. This is general to any required
+    solution representation and is not restricted to cell-centered values. For example, this may be used to represent
+    face reconstruction states.
+
+    Args:
+        gas: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
+        num_cells: Number of finite volume cells represented by this SolutionPhys.
+        sol_prim_in: NumPy array of the primitive state profiles that this SolutionPhys represents.
+        sol_cons_in: NumPy array of the conservative state profiles that this SolutionPhys represents.
+
+    Attributes:
+        gas_model: GasModel associated with the SolutionDomain with which this SolutionPhys is associated.
+        num_cells: Number of finite volume cells represented by this SolutionPhys.
+        sol_prim: NumPy array of the primitive state profiles that this SolutionPhys represents.
+        sol_cons: NumPy array of the conservative state profiles that this SolutionPhys represents.
+        mass_fracs_full: NumPy array of all num_species_full mass fraction profiles.
+        mw_mix: NumPy array of the mixture molecular weight profile, in g/mol.
+        r_mix: NumPy array of the mixture specific gas constant profile, in J/kg-K.
+        gamma_mix: NumPy array of the mixture ratio of specific heats profile.
+        enth_ref_mix: NumPy array of the mixture reference enthalpy profile, in J/kg.
+        cp_mix: NumPy array of the mixture specific heat capacity at constant pressure profile, in J/kg-K.
+        h0: NumPy array of the stangation enthalpy profile, in J/kg.
+        hi: NumPy array of the species enthalpy profiles for all num_species_full chemical species, in J/kg.
+        c: NumPy array of the sound speed profile, in m/s.
+        dyn_visc_mix: NumPy array of the mixture dynamic viscosity profile, in N-s/m^2.
+        therm_cond_mix: NumPy array of the mixture thermal conductivity, in W/m-K.
+        mass_diff_mix:
+            NumPy array of the mass diffusivity profiles for all num_species_full chemical species, in m^2/s.
+        d_rho_d_press: NumPy array of derivative of density w/r/t pressure profile.
+        d_rho_d_temp: NumPy array of derivative of density w/r/t temperature profile.
+        d_rho_d_mass_frac: NumPy array of derivative of density w/r/t the first num_species mass fraction profiles.
+        d_enth_d_press: NumPy array of derivative of stagnation enthalpy w/r/t pressure profile.
+        d_enth_d_temp: NumPy array of derivative of stagnation enthalpy w/r/t temperature profile.
+        d_enth_d_mass_frac:
+            NumPy array of derivative of stagnation enthalpy w/r/t the first num_species mass fraction profiles.
     """
 
     def __init__(self, gas, num_cells, sol_prim_in=None, sol_cons_in=None):
@@ -14,31 +50,31 @@ class SolutionPhys:
 
         self.num_cells = num_cells
 
-        # primitive and conservative state
+        # Primitive and conservative state
         self.sol_prim = np.zeros((self.gas_model.num_eqs, num_cells), dtype=REAL_TYPE)
         self.sol_cons = np.zeros((self.gas_model.num_eqs, num_cells), dtype=REAL_TYPE)
 
-        # all species mass fractions, avoid calculation of last species
+        # All species mass fractions, avoid re-calculation of last species
         self.mass_fracs_full = np.zeros((self.gas_model.num_species_full, num_cells), dtype=REAL_TYPE)
 
-        # chemical properties
+        # Chemical properties
         self.mw_mix = np.zeros(num_cells, dtype=REAL_TYPE)
         self.r_mix = np.zeros(num_cells, dtype=REAL_TYPE)
         self.gamma_mix = np.zeros(num_cells, dtype=REAL_TYPE)
 
-        # thermodynamic properties
+        # Thermodynamic properties
         self.enth_ref_mix = np.zeros(num_cells, dtype=REAL_TYPE)
         self.cp_mix = np.zeros(num_cells, dtype=REAL_TYPE)
         self.h0 = np.zeros(num_cells, dtype=REAL_TYPE)
         self.hi = np.zeros((self.gas_model.num_species_full, num_cells), dtype=REAL_TYPE)
         self.c = np.zeros(num_cells, dtype=REAL_TYPE)
 
-        # transport properties
+        # Transport properties
         self.dyn_visc_mix = np.zeros(num_cells, dtype=REAL_TYPE)
         self.therm_cond_mix = np.zeros(num_cells, dtype=REAL_TYPE)
         self.mass_diff_mix = np.zeros((self.gas_model.num_species_full, num_cells), dtype=REAL_TYPE)
 
-        # derivatives of density and enthalpy
+        # Derivatives of density and enthalpy
         self.d_rho_d_press = np.zeros(num_cells, dtype=REAL_TYPE)
         self.d_rho_d_temp = np.zeros(num_cells, dtype=REAL_TYPE)
         self.d_rho_d_mass_frac = np.zeros((self.gas_model.num_species, num_cells), dtype=REAL_TYPE)
@@ -46,7 +82,7 @@ class SolutionPhys:
         self.d_enth_d_temp = np.zeros(num_cells, dtype=REAL_TYPE)
         self.d_enth_d_mass_frac = np.zeros((self.gas_model.num_species, num_cells), dtype=REAL_TYPE)
 
-        # set initial condition
+        # Set initial condition
         if sol_prim_in is not None:
             assert sol_prim_in.shape == (self.gas_model.num_eqs, num_cells)
             self.sol_prim = sol_prim_in.copy()
@@ -56,11 +92,15 @@ class SolutionPhys:
             self.sol_cons = sol_cons_in.copy()
             self.update_state(from_cons=True)
         else:
-            raise ValueError("Must provide either sol_prim_in or sol_cons_in to solutionPhys")
+            raise ValueError("Must provide either sol_prim_in or sol_cons_in to SolutionPhys")
 
     def update_state(self, from_cons=True):
-        """
-        Update state and some mixture gas properties
+        """Utility function to update primitive state from conservative state or vice versa.
+
+        Args:
+            from_cons: 
+                If True, update primitive state from conservative state. 
+                If False, update conservative state from primitive state.
         """
 
         if from_cons:
@@ -69,15 +109,18 @@ class SolutionPhys:
             self.calc_state_from_prim()
 
     def calc_state_from_cons(self):
-        """
-        Compute primitive state from conservative state
+        """Compute primitive state from conservative state, and thermodynamic properties.
+
+        First backs out mass fractions from density-weighted mass fractions and thresholds them,
+        calculates thermodynamic properties, then computes remaining primitive solution profiles
+        from equations of state.
         """
 
         # TODO: store some other things by default
         # 	mixture molecular weight
         # 	species enthalpies
 
-        # mass fractions
+        # Mass fractions
         self.sol_prim[3:, :] = self.sol_cons[3:, :] / self.sol_cons[[0], :]
         mass_fracs = self.gas_model.get_mass_frac_array(sol_prim_in=self.sol_prim)
         mass_fracs = self.gas_model.calc_all_mass_fracs(mass_fracs, threshold=True)
@@ -87,14 +130,14 @@ class SolutionPhys:
         self.sol_prim[3:, :] = mass_fracs
         self.sol_cons[3:, :] = self.sol_prim[3:, :] * self.sol_cons[[0], :]
 
-        # update thermo properties
+        # Update thermo properties
         self.enth_ref_mix = self.gas_model.calc_mix_enth_ref(mass_fracs)
         self.r_mix = self.gas_model.calc_mix_gas_constant(mass_fracs)
         self.cp_mix = self.gas_model.calc_mix_cp(mass_fracs)
         self.gamma_mix = self.gas_model.calc_mix_gamma(self.r_mix, self.cp_mix)
 
-        # update primitive state
-        # TODO: gas_model references
+        # Update primitive state
+        # TODO: GasModel references
         self.sol_prim[1, :] = self.sol_cons[1, :] / self.sol_cons[0, :]
         self.sol_prim[2, :] = (
             self.sol_cons[2, :] / self.sol_cons[0, :] - np.square(self.sol_prim[1, :]) / 2.0 - self.enth_ref_mix
@@ -102,14 +145,16 @@ class SolutionPhys:
         self.sol_prim[0, :] = self.sol_cons[0, :] * self.r_mix * self.sol_prim[2, :]
 
     def calc_state_from_prim(self):
-        """
-        Compute state from primitive state
+        """Compute primitive state from conservative state, and thermodynamic properties.
+
+        Thresholds mass fractions, calculates thermodynamic properties,
+        then computes conservative solution profiles from equations of state.
         """
 
         # TODO: store some other things by default
         # 	species enthalpies
 
-        # mass fractions
+        # Mass fractions
         mass_fracs = self.gas_model.get_mass_frac_array(sol_prim_in=self.sol_prim)
         mass_fracs = self.gas_model.calc_all_mass_fracs(mass_fracs, threshold=True)
         self.mass_fracs_full[:, :] = mass_fracs.copy()
@@ -118,14 +163,14 @@ class SolutionPhys:
         self.sol_prim[3:, :] = mass_fracs
         self.mw_mix = self.gas_model.calc_mix_mol_weight(self.mass_fracs_full)
 
-        # update thermo properties
+        # Update thermo properties
         self.enth_ref_mix = self.gas_model.calc_mix_enth_ref(mass_fracs)
         self.r_mix = self.gas_model.calc_mix_gas_constant(mass_fracs)
         self.cp_mix = self.gas_model.calc_mix_cp(mass_fracs)
         self.gamma_mix = self.gas_model.calc_mix_gamma(self.r_mix, self.cp_mix)
 
-        # update conservative variables
-        # TODO: gas_model references
+        # Update conservative variables
+        # TODO: GasModel references
         self.sol_cons[0, :] = self.sol_prim[0, :] / (self.r_mix * self.sol_prim[2, :])
         self.sol_cons[1, :] = self.sol_cons[0, :] * self.sol_prim[1, :]
         self.sol_cons[2, :] = (
@@ -135,12 +180,11 @@ class SolutionPhys:
         self.sol_cons[3:, :] = self.sol_cons[[0], :] * self.sol_prim[3:, :]
 
     def calc_state_from_rho_h0(self):
-        """
-        Adjust pressure and temperature iteratively to agree with
-        a fixed density and stagnation enthalpy
+        """Iteratively solve for pressure and temperature given fixed density and stagnation enthalpy.
 
-        Used to compute a physically-meaningful Roe average state
-        from the Roe average enthalpy and density
+        Used to compute a physically-meaningful Roe average state from the Roe average enthalpy and density.
+        The simple Roe average of all primitive fields, stagnation enthalpy, and density will
+        result in an inconsistent state description otherwise.
         """
 
         # TODO: some of this changes for TPG
@@ -164,13 +208,11 @@ class SolutionPhys:
             hi_curr = self.gas_model.calc_spec_enth(self.sol_prim[2, :])
             h0_curr = self.gas_model.calc_stag_enth(self.sol_prim[1, :], self.mass_fracs_full, spec_enth=hi_curr)
 
-            # Compute difference between current
-            # and fixed density/stagnation enthalpy
+            # Compute difference between current and fixed density/stagnation enthalpy
             d_dens = rho_fixed - dens_curr
             d_stag_enth = h0_fixed - h0_curr
 
-            # Compute derivatives of density and stagnation enthalpy
-            # with respect to pressure and temperature
+            # Compute derivatives of density and stagnation enthalpy with respect to pressure and temperature
             d_dens_d_press, d_dens_d_temp = self.gas_model.calc_dens_derivs(
                 dens_curr, wrt_press=True, pressure=self.sol_prim[0, :], wrt_temp=True, temperature=self.sol_prim[2, :]
             )

--- a/perform/system_solver.py
+++ b/perform/system_solver.py
@@ -1,11 +1,7 @@
 import os
-from math import floor, log
-
-import numpy as np
 
 import perform.constants as const
-from perform.input_funcs import read_input_file, catch_input, catch_list
-from perform.mesh import Mesh
+from perform.input_funcs import read_input_file, catch_input
 from perform.misc_funcs import mkdir_shallow
 
 
@@ -25,7 +21,7 @@ class SystemSolver:
         probe_output_dir: Path to directory for probe monitor data output.
         image_output_dir: Path to directory for visualization plot image output.
         restart_output_dir: Path to directory for restart file output.
-        init_file: Path to NumPy binary file of initial condition primitive solution profiles, if desired. 
+        init_file: Path to NumPy binary file of initial condition primitive solution profiles, if desired.
         dt: Physical time step size, in seconds.
         time_scheme:
             String name of the numerical time integration scheme to apply to the SolutionDomain.

--- a/perform/system_solver.py
+++ b/perform/system_solver.py
@@ -71,7 +71,6 @@ class SystemSolver:
 
     # TODO: time_scheme should not be associated with SystemSolver
 
-
     def __init__(self, working_dir):
 
         # input parameters from solverParams.inp

--- a/perform/system_solver.py
+++ b/perform/system_solver.py
@@ -10,9 +10,67 @@ from perform.misc_funcs import mkdir_shallow
 
 
 class SystemSolver:
+    """Container class for global solver parameters.
+
+    This class simply stores parameters which apply to the entire simulation, across all SolutionDomain's.
+    It handles much of the input from the solver parameter input file, as well as handling parameters for outputs.
+
+    Args:
+        working_dir: Working directory of the current simulation.
+
+    Attributes:
+        working_dir: Working directory of the current simulation.
+        param_dict: Dictionary of parameters read from the solver parameters input file.
+        unsteady_output_dir: Path to directory for unsteady field data output.
+        probe_output_dir: Path to directory for probe monitor data output.
+        image_output_dir: Path to directory for visualization plot image output.
+        restart_output_dir: Path to directory for restart file output.
+        init_file: Path to NumPy binary file of initial condition primitive solution profiles, if desired. 
+        dt: Physical time step size, in seconds.
+        time_scheme:
+            String name of the numerical time integration scheme to apply to the SolutionDomain.
+        run_steady: Boolean flag indicating whether to run in "steady" mode.
+        num_steps: Total number of physical time steps to simulate.
+        iter: One-indexed simulation time step iteration number, always starts from one.
+        sol_time: Physical solution time of current time step iteration, in seconds.
+        time_iter:
+            One-indexed physical time step iteration. Currently starts from one, but at some point will be
+            changed to allow different numbers when initializing from init_file or a restart file.
+        steady_tol:
+            Primitive solution change norm residual threshold below which the "steady" solve is
+            considered to be "converged".
+        save_restarts: Boolean flag indicating whether to save restart files.
+        restart_interval: Time step iteration interval at which to save restart files, if save_restarts is True.
+        num_restarts: Maximum number of restart files to retain.
+        restart_iter: One-indexed current restart file number. Overwritten if initializing from a restart file.
+        init_from_restart:
+            Boolean flag indicating whether to load the primitive solution profile initial condition
+            from a restart file.
+        ic_params_file:
+            Path to text file including input parameters for defining a piecewise uniform
+            initial condition primitive solution profile.
+        out_interval: Time step iteration interval at which to store unsteady field profile data in a snapshot matrix.
+        prim_out: Boolean flag indicating whether to store and save primitive solution profile snapshots.
+        cons_out: Boolean flag indicating whether to store and save conservative solution profile snapshots.
+        source_out: Boolean flag indicating whether to store and save source term profile snapshots.
+        rhs_out:
+            Boolean flag indicating whether to store and save semi-discrete right-hand side function profile snapshots.
+        num_snaps: Total number of snapshots to be stored and saved, assuming the simulation runs to completion.
+        vel_add: Velocity to add to the entire initial condition velocity field, in m/s.
+        res_norm_prim:
+            List of normalization factors for primitive solution variables when computing
+            linear solve residual or solution change norms.
+        source_off: Boolean flag indicating whether the source term should be turned off.
+        solve_failed: Boolean flag indicating whether the solution has failed.
+        num_probes: Number of probe monitors to be recorded.
+        probe_vars: List of strings for variables which the probe monitors are to measure.
+        calc_rom: Boolean flag indicating whether to run a ROM simulation.
+        sim_type: Either "FOM" for a FOM simulation, or "ROM" for a ROM simulation.
+        rom_inputs: Path to ROM parameters input file.
     """
-    Container class for solver parameters
-    """
+
+    # TODO: time_scheme should not be associated with SystemSolver
+
 
     def __init__(self, working_dir):
 

--- a/perform/time_integrator/__init__.py
+++ b/perform/time_integrator/__init__.py
@@ -4,7 +4,7 @@ from perform.time_integrator.implicit_integrator import BDF
 
 def get_time_integrator(time_scheme, param_dict):
     """Helper function to get time integrator object.
-    
+
     Args:
         time_scheme: String name of the requested time scheme.
         param_dict: Dictionary of parameters read from the solver parameters input file.

--- a/perform/time_integrator/__init__.py
+++ b/perform/time_integrator/__init__.py
@@ -3,8 +3,14 @@ from perform.time_integrator.implicit_integrator import BDF
 
 
 def get_time_integrator(time_scheme, param_dict):
-    """
-    Helper function to get time integrator object
+    """Helper function to get time integrator object.
+    
+    Args:
+        time_scheme: String name of the requested time scheme.
+        param_dict: Dictionary of parameters read from solver_params.inp.
+
+    Returns:
+        TimeIntegrator object of the requested type.
     """
 
     if time_scheme == "bdf":

--- a/perform/time_integrator/__init__.py
+++ b/perform/time_integrator/__init__.py
@@ -7,7 +7,7 @@ def get_time_integrator(time_scheme, param_dict):
     
     Args:
         time_scheme: String name of the requested time scheme.
-        param_dict: Dictionary of parameters read from solver_params.inp.
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Returns:
         TimeIntegrator object of the requested type.

--- a/perform/time_integrator/explicit_integrator.py
+++ b/perform/time_integrator/explicit_integrator.py
@@ -12,7 +12,7 @@ class ExplicitIntegrator(TimeIntegrator):
     All child classes must implement the solve_sol_change() member function.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp.
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         time_type: Set to "explicit".
@@ -41,7 +41,7 @@ class RKExplicit(ExplicitIntegrator):
     Please refer to the solver theory documentation for more details on each method.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         rk_rhs: List of NumPy arrays of prior RK iteration RHS evaluations.
@@ -115,7 +115,7 @@ class ClassicRK4(RKExplicit):
     """Classic explicit RK4 scheme.
     
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         subiter_max: Total number of subiterations for one physical time step.
@@ -143,7 +143,7 @@ class SSPRK3(RKExplicit):
     """Strong stability-preserving explicit RK3 scheme.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         subiter_max: Total number of subiterations for one physical time step.
@@ -172,7 +172,7 @@ class JamesonLowStore(RKExplicit):
     Not actually low-storage to work with general RK format, just maintained here for consistency with old code.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         subiter_max: Total number of subiterations for one physical time step.

--- a/perform/time_integrator/explicit_integrator.py
+++ b/perform/time_integrator/explicit_integrator.py
@@ -7,8 +7,17 @@ from perform.time_integrator.time_integrator import TimeIntegrator
 
 
 class ExplicitIntegrator(TimeIntegrator):
-    """
-    Base class for explicit time integrators
+    """Base class for explicit time integrators.
+
+    All child classes must implement the solve_sol_change() member function.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp.
+
+    Attributes:
+        time_type: Set to "explicit".
+        dual_time: Set to False.
+        adapt_dtau: Set to False.
     """
 
     def __init__(self, param_dict):
@@ -24,8 +33,18 @@ class ExplicitIntegrator(TimeIntegrator):
 
 
 class RKExplicit(ExplicitIntegrator):
-    """
-    Explicit Runge-Kutta schemes
+    """ Base class for explicit Runge-Kutta time integrators:
+
+    All child classes must simply define their Butcher tableu via the attributes rk_a, rk_b, and rk_c.
+    Additionally, each must set the variable subiter_max.
+    
+    Please refer to the solver theory documentation for more details on each method.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp
+
+    Attributes:
+        rk_rhs: List of NumPy arrays of prior RK iteration RHS evaluations.
     """
 
     def __init__(self, param_dict):
@@ -35,8 +54,13 @@ class RKExplicit(ExplicitIntegrator):
         self.rk_rhs = [None] * self.subiter_max  # subiteration RHS history
 
     def solve_sol_change(self, rhs):
-        """
-        Either compute intermediate step or final physical time step
+        """Compute intermediate step or final physical time step.
+        
+        Args:
+            rhs: Semi-discrete governing ODE right-hand side function evaluation.
+
+        Returns:
+            NumPy array of the change in the solution profile.
         """
 
         self.rk_rhs[self.subiter] = rhs.copy()
@@ -51,8 +75,13 @@ class RKExplicit(ExplicitIntegrator):
         return dsol
 
     def solve_sol_change_subiter(self, rhs):
-        """
-        Change in intermediate solution for subiteration
+        """Change in intermediate solution for subiteration.
+        
+        Args:
+            rhs: NumPy array of the semi-discrete governing ODE right-hand side function evaluation.
+
+        Returns:
+            NumPy array of the change in the solution profile between subiterations.
         """
 
         dsol = np.zeros(rhs.shape, dtype=REAL_TYPE)
@@ -64,8 +93,13 @@ class RKExplicit(ExplicitIntegrator):
         return dsol
 
     def solve_sol_change_iter(self, rhs):
-        """
-        Change in physical solution
+        """Compute change in physical solution at final subiteration.
+
+        Args:
+            rhs: NumPy array of the semi-discrete governing ODE right-hand side function evaluation.
+
+        Returns:
+            NumPy array of the change in the solution profile for final subiteration.
         """
 
         dsol = np.zeros(rhs.shape, dtype=REAL_TYPE)
@@ -78,8 +112,13 @@ class RKExplicit(ExplicitIntegrator):
 
 
 class ClassicRK4(RKExplicit):
-    """
-    Classic explicit RK4 scheme
+    """Classic explicit RK4 scheme.
+    
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp
+
+    Attributes:
+        subiter_max: Total number of subiterations for one physical time step.
     """
 
     def __init__(self, param_dict):
@@ -101,8 +140,13 @@ class ClassicRK4(RKExplicit):
 
 
 class SSPRK3(RKExplicit):
-    """
-    Strong stability-preserving explicit RK3 scheme
+    """Strong stability-preserving explicit RK3 scheme.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp
+
+    Attributes:
+        subiter_max: Total number of subiterations for one physical time step.
     """
 
     def __init__(self, param_dict):
@@ -122,12 +166,16 @@ class SSPRK3(RKExplicit):
 
 
 class JamesonLowStore(RKExplicit):
-    """
-    "Low-storage" class of RK schemes by Jameson
+    """"Low-storage" class of RK schemes by Jameson.
     
-    Not actually appropriate for unsteady problems, supposedly
-    
-    Not actually low-storage to work with general RK format, just maintained here for consistency with old code
+    Not actually appropriate for unsteady problems, supposedly.
+    Not actually low-storage to work with general RK format, just maintained here for consistency with old code.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp
+
+    Attributes:
+        subiter_max: Total number of subiterations for one physical time step.
     """
 
     def __init__(self, param_dict):

--- a/perform/time_integrator/explicit_integrator.py
+++ b/perform/time_integrator/explicit_integrator.py
@@ -37,7 +37,7 @@ class RKExplicit(ExplicitIntegrator):
 
     All child classes must simply define their Butcher tableu via the attributes rk_a, rk_b, and rk_c.
     Additionally, each must set the variable subiter_max.
-    
+
     Please refer to the solver theory documentation for more details on each method.
 
     Args:
@@ -55,7 +55,7 @@ class RKExplicit(ExplicitIntegrator):
 
     def solve_sol_change(self, rhs):
         """Compute intermediate step or final physical time step.
-        
+
         Args:
             rhs: Semi-discrete governing ODE right-hand side function evaluation.
 
@@ -76,7 +76,7 @@ class RKExplicit(ExplicitIntegrator):
 
     def solve_sol_change_subiter(self, rhs):
         """Change in intermediate solution for subiteration.
-        
+
         Args:
             rhs: NumPy array of the semi-discrete governing ODE right-hand side function evaluation.
 
@@ -113,7 +113,7 @@ class RKExplicit(ExplicitIntegrator):
 
 class ClassicRK4(RKExplicit):
     """Classic explicit RK4 scheme.
-    
+
     Args:
         param_dict: Dictionary of parameters read from the solver parameters input file.
 
@@ -167,7 +167,7 @@ class SSPRK3(RKExplicit):
 
 class JamesonLowStore(RKExplicit):
     """"Low-storage" class of RK schemes by Jameson.
-    
+
     Not actually appropriate for unsteady problems, supposedly.
     Not actually low-storage to work with general RK format, just maintained here for consistency with old code.
 

--- a/perform/time_integrator/implicit_integrator.py
+++ b/perform/time_integrator/implicit_integrator.py
@@ -34,9 +34,9 @@ class ImplicitIntegrator(TimeIntegrator):
     """
 
     def __init__(self, param_dict):
-        
+
         super().__init__(param_dict)
-        
+
         self.time_type = "implicit"
         self.subiter_max = catch_input(param_dict, "subiter_max", const.SUBITER_MAX_IMP_DEFAULT)
         self.res_tol = catch_input(param_dict, "res_tol", const.L2_RES_TOL_DEFAULT)
@@ -92,7 +92,6 @@ class BDF(ImplicitIntegrator):
         Returns:
             NumPy array of the fully-discrete residual profiles.
         """
-
 
         # Account for cold start
         time_order = min(solver.iter, self.time_order)

--- a/perform/time_integrator/implicit_integrator.py
+++ b/perform/time_integrator/implicit_integrator.py
@@ -7,13 +7,36 @@ from perform.time_integrator.time_integrator import TimeIntegrator
 
 
 class ImplicitIntegrator(TimeIntegrator):
-    """
-    Base class for implicit time integrators
-    Solves implicit system via Newton's method
+    """Base class for implicit time integrators.
+    
+    Solves implicit system via Newton's method.
+
+    Each child class must implement a calc_residual() member function.
+
+    Please refer to the solver theory documentation for details on each method.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp.
+
+    Attributes:
+        time_type: Set to "implicit".
+        subiter_max:
+            Maximum number of subiterations to execute before terminating the iterative solve,
+            regardless of convergence.
+        res_tol:
+            Residual norm tolerance, below which Newton's method for a physical time step is considered
+            to be converged and subiteration is terminated.
+        dual_time: Boolean flag indicating whether to use dual time-stepping.
+        dtau: Dual time step size, in seconds.
+        adapt_dtau: Boolean flag to indicate whether to adapt dtau, if dual_time == True.
+        cfl: Courant–Friedrichs–Lewy number to adapt dtau based on maximum wave speed in each cell.
+        vnn: von Neumann number to adapt dtau based on the mixture kinematic viscosity in each cell.
     """
 
     def __init__(self, param_dict):
+        
         super().__init__(param_dict)
+        
         self.time_type = "implicit"
         self.subiter_max = catch_input(param_dict, "subiter_max", const.SUBITER_MAX_IMP_DEFAULT)
         self.res_tol = catch_input(param_dict, "res_tol", const.L2_RES_TOL_DEFAULT)
@@ -27,13 +50,18 @@ class ImplicitIntegrator(TimeIntegrator):
             self.adapt_dtau = False
         self.cfl = catch_input(param_dict, "cfl", const.CFL_DEFAULT)
         self.vnn = catch_input(param_dict, "vnn", const.VNN_DEFAULT)
-        self.ref_const = catch_input(param_dict, "ref_const", [None])
-        self.relax_const = catch_input(param_dict, "relax_const", [None])
 
 
 class BDF(ImplicitIntegrator):
-    """
-    Backwards difference formula (up to fourth-order)
+    """Backwards differentiation formula.
+
+    Supports up to fourth-order accuracy, though anything greater than second-order is generally not stable.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp.
+
+    Attributes:
+        coeffs: List of NumPy arrays containing the time derivative discretization coefficients for each order of accuracy.
     """
 
     def __init__(self, param_dict):
@@ -49,6 +77,22 @@ class BDF(ImplicitIntegrator):
         )
 
     def calc_residual(self, sol_hist, rhs, solver, samp_idxs=np.s_[:]):
+        """Compute fully-discrete residual.
+
+        Args:
+            sol_hist:
+                List of NumPy arrays representing the recent conservative state solution history,
+                as many as are required to compute the maximum order of accuracy requested.
+            rhs: NumPy array of the semi-discrete governing ODE right-hand side function evaluation.
+            solver: SystemSolver containing global simulation parameters. 
+            samp_idxs:
+                Either a NumPy slice or NumPy array for selecting sampled cells to compute the residual at.
+                Used for hyper-reduction of projection-based reduced-order models.
+
+        Returns:
+            NumPy array of the fully-discrete residual profiles.
+        """
+
 
         # Account for cold start
         time_order = min(solver.iter, self.time_order)

--- a/perform/time_integrator/implicit_integrator.py
+++ b/perform/time_integrator/implicit_integrator.py
@@ -8,7 +8,7 @@ from perform.time_integrator.time_integrator import TimeIntegrator
 
 class ImplicitIntegrator(TimeIntegrator):
     """Base class for implicit time integrators.
-    
+
     Solves implicit system via Newton's method.
 
     Each child class must implement a calc_residual() member function.
@@ -61,7 +61,7 @@ class BDF(ImplicitIntegrator):
         param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
-        coeffs: List of NumPy arrays containing the time derivative discretization coefficients for each order of accuracy.
+        coeffs: List of NumPy arrays of the time derivative discretization coefficients for each order of accuracy.
     """
 
     def __init__(self, param_dict):
@@ -84,7 +84,7 @@ class BDF(ImplicitIntegrator):
                 List of NumPy arrays representing the recent conservative state solution history,
                 as many as are required to compute the maximum order of accuracy requested.
             rhs: NumPy array of the semi-discrete governing ODE right-hand side function evaluation.
-            solver: SystemSolver containing global simulation parameters. 
+            solver: SystemSolver containing global simulation parameters.
             samp_idxs:
                 Either a NumPy slice or NumPy array for selecting sampled cells to compute the residual at.
                 Used for hyper-reduction of projection-based reduced-order models.

--- a/perform/time_integrator/implicit_integrator.py
+++ b/perform/time_integrator/implicit_integrator.py
@@ -16,7 +16,7 @@ class ImplicitIntegrator(TimeIntegrator):
     Please refer to the solver theory documentation for details on each method.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp.
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         time_type: Set to "implicit".
@@ -58,7 +58,7 @@ class BDF(ImplicitIntegrator):
     Supports up to fourth-order accuracy, though anything greater than second-order is generally not stable.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp.
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         coeffs: List of NumPy arrays containing the time derivative discretization coefficients for each order of accuracy.

--- a/perform/time_integrator/time_integrator.py
+++ b/perform/time_integrator/time_integrator.py
@@ -1,6 +1,22 @@
 class TimeIntegrator:
-    """
-    Base class for time integrators
+    """Base class for all numerical time integrators.
+
+    Child classes implement explicit and implicit time integration schemes.
+
+    Each SolutionDomain has its own TimeIntegrator, which permits ROM-ROM and FOM-ROM coupling
+    with various time integrators.
+
+    Args:
+        param_dict: Dictionary of parameters read from solver_params.inp.
+
+    Attributes:
+        dt: Physical time step size, in seconds.
+        time_scheme:
+            String name of the numerical time integration scheme to apply to the SolutionDomain with which
+            this TimeIntegrator is associated.
+        time_order:
+            Time order of accuracy. Is fixed for some time integrators, and a limited range is supported by others.
+        subiter: Zero-indexed physical time step subiteration number.
     """
 
     def __init__(self, param_dict):

--- a/perform/time_integrator/time_integrator.py
+++ b/perform/time_integrator/time_integrator.py
@@ -7,7 +7,7 @@ class TimeIntegrator:
     with various time integrators.
 
     Args:
-        param_dict: Dictionary of parameters read from solver_params.inp.
+        param_dict: Dictionary of parameters read from the solver parameters input file.
 
     Attributes:
         dt: Physical time step size, in seconds.

--- a/perform/visualization/field_plot.py
+++ b/perform/visualization/field_plot.py
@@ -81,7 +81,7 @@ class FieldPlot(Visualization):
 
     def plot(self, sol_prim, sol_cons, source, rhs, gas, x_cell, line_style, first_plot):
         """Draw and display field plot.
-        
+
         Saves a decent amount of time by using set_ydata instead of repeatedly clearing axes and replotting.
 
         Args:

--- a/perform/visualization/field_plot.py
+++ b/perform/visualization/field_plot.py
@@ -8,8 +8,36 @@ from perform.visualization.visualization import Visualization
 
 
 class FieldPlot(Visualization):
-    """
-    Class for field plot image
+    """Class for field plot visualization.
+
+    Produces "snapshots" of flow field profiles at the interval specified by vis_interval.
+
+    Must be manually expanded to plot specific profiles.
+
+    Args:
+        image_output_dir: Base image output directory, within the working directory.
+        vis_id: Zero-indexed ID of this Visualization.
+        vis_interval: Physical time step interval at which to display/save visualization plots.
+        num_steps: Total number of physical time steps to be executed by this simulation.
+        sim_type: "FOM" or "ROM", depending on simulation type.
+        vis_vars: List of num_subplots strings of variables to be visualized.
+        vis_x_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            x-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        vis_y_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            y-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        species_names: List of strings of names for all num_species_full chemical species.
+
+    Attributes:
+        vis_type: Set to "field".
+        x_label: Set to "x (m)", x-axis label.
+        num_imgs:
+            Total number of field plot images that are expected to be generated, under the assumption
+            that the simulation completes without failure.
+        img_string: String within which the output image number will be inserted for image file name generation.
+        ax_line: List of matplotlib.lines.Line2D artists for each subplot.
+        img_dir: Output director where image files will be saved.
     """
 
     def __init__(
@@ -52,8 +80,19 @@ class FieldPlot(Visualization):
             os.mkdir(self.img_dir)
 
     def plot(self, sol_prim, sol_cons, source, rhs, gas, x_cell, line_style, first_plot):
-        """
-        Draw and display field plot
+        """Draw and display field plot.
+        
+        Saves a decent amount of time by using set_ydata instead of repeatedly clearing axes and replotting.
+
+        Args:
+            sol_prim: NumPy array of the primitive state profiles from SolutionInterior.
+            sol_cons: NumPy array of the conservative state profiles from SolutionInterior.
+            source: NumPy array of the reaction source term profiles for the num_species species transport equations.
+            rhs: NumPy array of the evaluation of the right-hand side function of the semi-discrete governing ODE.
+            gas: GasModel object associated with the SolutionDomain.
+            x_cell: Coordinates of Mesh cell centers.
+            line_style: String containing matplotlib.pyplot line style option.
+            first_plot: Boolean flag indicating whether this is the first time the plot is being drawn.
         """
 
         plt.figure(self.vis_id)
@@ -98,8 +137,20 @@ class FieldPlot(Visualization):
         self.fig.canvas.draw()
 
     def get_y_data(self, sol_prim, sol_cons, source, rhs, var_str, gas):
-        """
-        Extract plotting data from flow field domain data
+        """Extract plotting data from flow field domain data.
+
+        New inputs and var_str options must be manually added to permit new profiles to be plotted.
+
+        Args:
+            sol_prim: NumPy array of the primitive state profiles from SolutionInterior.
+            sol_cons: NumPy array of the conservative state profiles from SolutionInterior.
+            source: NumPy array of the reaction source term profiles for the num_species species transport equations.
+            rhs: NumPy array of the evaluation of the right-hand side function of the semi-discrete governing ODE.
+            var_str: String corresponding to variable profile to be plotted.
+            gas: GasModel object associated with the SolutionDomain.
+
+        Returns:
+            NumPy array of the flow field profile to be visualized.
         """
 
         if var_str == "pressure":
@@ -123,7 +174,6 @@ class FieldPlot(Visualization):
                 y_data = massFracs[-1, :]
             else:
                 y_data = sol_prim[3 + spec_idx - 1, :]
-        # TODO: Get density-species for last species
         elif var_str[:15] == "density-species":
             spec_idx = int(var_str[16:])
             y_data = sol_cons[3 + spec_idx - 1, :]
@@ -133,8 +183,11 @@ class FieldPlot(Visualization):
         return y_data
 
     def save(self, iter_num, dpi=100):
-        """
-        Save plot to disk
+        """Save plot to disk.
+
+        Args:
+            iter_num: One-indexed simulation iteration number.
+            dpi: Dots per inch of figure, determines resolution.
         """
 
         plt.figure(self.vis_id)

--- a/perform/visualization/probe_plot.py
+++ b/perform/visualization/probe_plot.py
@@ -40,6 +40,7 @@ class ProbePlot(Visualization):
         ax_line: List of matplotlib.lines.Line2D artists for each subplot.
         fig_file: 
     """
+
     def __init__(
         self,
         image_output_dir,

--- a/perform/visualization/probe_plot.py
+++ b/perform/visualization/probe_plot.py
@@ -38,7 +38,7 @@ class ProbePlot(Visualization):
         probe_num: One-indexed probe number, corresponding to labels given in the solver parameters input file.
         probe_vars: List of strings of variables to be probed at each probe monitor location.
         ax_line: List of matplotlib.lines.Line2D artists for each subplot.
-        fig_file: 
+        fig_file: Path to visualization plot output image file.
     """
 
     def __init__(
@@ -82,7 +82,7 @@ class ProbePlot(Visualization):
 
     def plot(self, probe_vals, time_vals, iter_num, line_style, first_plot):
         """Draw and display probe plot.
-        
+
         Since shape of plotted data changes every time, can't use set_data.
         As a result, probe plotting can be pretty slow.
 

--- a/perform/visualization/probe_plot.py
+++ b/perform/visualization/probe_plot.py
@@ -23,7 +23,7 @@ class ProbePlot(Visualization):
         probe_vars: List of strings of variables to be probed at each probe monitor location.
         vis_vars: List of num_subplots strings of variables to be visualized.
         probe_num: One-indexed probe number.
-        num_probes: Total number of probe monitors set in solver_params.inp
+        num_probes: Total number of probe monitors set in the solver parameters input file
         vis_x_bounds:
             List of num_subplots lists, each of length 2 including lower and upper bounds on the
             x-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
@@ -35,7 +35,7 @@ class ProbePlot(Visualization):
     Attributes:
         vis_type: Set to "probe".
         x_label: Set to "t (s)", x-axis label.
-        probe_num: One-indexed probe number, corresponding to labels given in solver_params.inp.
+        probe_num: One-indexed probe number, corresponding to labels given in the solver parameters input file.
         probe_vars: List of strings of variables to be probed at each probe monitor location.
         ax_line: List of matplotlib.lines.Line2D artists for each subplot.
         fig_file: 

--- a/perform/visualization/probe_plot.py
+++ b/perform/visualization/probe_plot.py
@@ -5,11 +5,41 @@ import numpy as np
 
 from perform.visualization.visualization import Visualization
 
-# TODO: maybe easier to make probe/residual plots under some pointPlot class
+# TODO: maybe easier to make probe/residual plots under some PointPlot class
 # TODO: move some of the init input arguments used for assertions outside
 
 
 class ProbePlot(Visualization):
+    """Class for probe plot visualization.
+
+    Produces plots of the time history of probe monitors at the interval specified by vis_interval.
+
+    Must be manually expanded to plot specific profiles.
+
+    Args:
+        image_output_dir: Base image output directory, within the working directory.
+        vis_id: Zero-indexed ID of this Visualization.
+        sim_type: "FOM" or "ROM", depending on simulation type.
+        probe_vars: List of strings of variables to be probed at each probe monitor location.
+        vis_vars: List of num_subplots strings of variables to be visualized.
+        probe_num: One-indexed probe number.
+        num_probes: Total number of probe monitors set in solver_params.inp
+        vis_x_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            x-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        vis_y_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            y-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        species_names: List of strings of names for all num_species_full chemical species.
+
+    Attributes:
+        vis_type: Set to "probe".
+        x_label: Set to "t (s)", x-axis label.
+        probe_num: One-indexed probe number, corresponding to labels given in solver_params.inp.
+        probe_vars: List of strings of variables to be probed at each probe monitor location.
+        ax_line: List of matplotlib.lines.Line2D artists for each subplot.
+        fig_file: 
+    """
     def __init__(
         self,
         image_output_dir,
@@ -30,30 +60,37 @@ class ProbePlot(Visualization):
 
         self.probe_num = probe_num
         self.probe_vars = probe_vars
-        assert self.probe_num >= 0, "Must provide positive integer probe number for probe plot " + str(self.vis_id)
-        assert self.probe_num < num_probes, "probe_num_" + str(self.vis_id) + " must correspond to a valid probe"
+        assert self.probe_num > 0, "Must provide positive integer probe number for probe plot " + str(self.vis_id)
+        assert self.probe_num <= num_probes, "probe_num_" + str(self.vis_id) + " must correspond to a valid probe"
         assert vis_vars[0] is not None, "Must provide vis_vars for probe plot " + str(self.vis_id)
 
         super().__init__(vis_id, vis_vars, vis_x_bounds, vis_y_bounds, species_names)
 
         self.ax_line = [None] * self.num_subplots
 
-        # image file on disk
+        # Image file on disk
         vis_name = ""
         for vis_var in self.vis_vars:
             vis_name += "_" + vis_var
         fig_name = "probe" + vis_name + "_" + str(self.probe_num) + "_" + sim_type + ".png"
         self.fig_file = os.path.join(image_output_dir, fig_name)
 
-        # check that requested variables are being probed
+        # Check that requested variables are being probed
         for vis_var in self.vis_vars:
             assert vis_var in probe_vars, "Must probe " + vis_var + " to plot it"
 
     def plot(self, probe_vals, time_vals, iter_num, line_style, first_plot):
-        """
-        Draw and display probe plot
-        Since shape of plotted data changes every time, can't use set_data
-        As a result, probe plotting can be pretty slow
+        """Draw and display probe plot.
+        
+        Since shape of plotted data changes every time, can't use set_data.
+        As a result, probe plotting can be pretty slow.
+
+        Args:
+            probe_vals: NumPy array of probe monitor time history for each monitored variable.
+            time_vals: NumPy array of time values associated with each discrete time step, not including t = 0.
+            iter_num: One-indexed physical time step iteration number.
+            line_style: String containing matplotlib.pyplot line style option.
+            first_plot: Boolean flag indicating whether this is the first time the plot is being drawn.
         """
 
         plt.figure(self.vis_id)
@@ -77,7 +114,7 @@ class ProbePlot(Visualization):
 
                 ax_var.cla()
 
-                y_data = self.getYData(probe_vals, self.vis_vars[lin_idx], iter_num)
+                y_data = self.get_y_data(probe_vals, self.vis_vars[lin_idx], iter_num)
                 x_data = time_vals[:iter_num]
 
                 (self.ax_line[lin_idx],) = ax_var.plot(x_data, y_data, line_style)
@@ -92,15 +129,29 @@ class ProbePlot(Visualization):
             self.fig.tight_layout()
         self.fig.canvas.draw()
 
-    def getYData(self, probe_vals, var_str, iter_num):
+    def get_y_data(self, probe_vals, var_str, iter_num):
+        """Extract probe data to be plotted from probe_vals.
 
-        # data extraction of probes is done in solDomain
+        Data extraction of probe monitor data is done in SolutionDomain, this just selects the correct variable.
+
+        Args:
+            probe_vals: NumPy array of probe monitor time history for each monitored variable.
+            var_str: String corresponding to variable profile to be plotted.
+            iter_num: One-indexed simulation iteration number.
+        """
+
         var_idx = np.squeeze(np.argwhere(self.probe_vars == var_str)[0])
         y_data = probe_vals[self.probe_num, var_idx, :iter_num]
 
         return y_data
 
     def save(self, iter_num, dpi=100):
+        """Save plot to disk.
+
+        Args:
+            iter_num: One-indexed simulation iteration number.
+            dpi: Dots per inch of figure, determines resolution.
+        """
 
         plt.figure(self.vis_id)
         self.fig.savefig(self.fig_file, dpi=dpi)

--- a/perform/visualization/visualization.py
+++ b/perform/visualization/visualization.py
@@ -1,8 +1,4 @@
-import numpy as np
 import matplotlib as mpl
-import matplotlib.pyplot as plt
-import matplotlib.ticker as plticker
-import matplotlib.gridspec as gridspec
 
 mpl.rc("font", family="serif", size="10")
 mpl.rc("axes", labelsize="x-large")

--- a/perform/visualization/visualization.py
+++ b/perform/visualization/visualization.py
@@ -15,6 +15,40 @@ mpl.rc("text.latex", preamble=r"\usepackage{amsmath}")
 
 
 class Visualization:
+    """Base class for visualization plots.
+
+    Processes input parameters for plotting, such as axis bounds, arrangement of subplots, and axis labels.
+
+    Child classes must implement the plot() and save() member functions.
+
+    Args:
+        vis_id: Zero-indexed ID of this Visualization.
+        vis_vars: List of num_subplots strings of variables to be visualized.
+        vis_x_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            x-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        vis_y_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            y-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        species_names: List of strings of names for all num_species_full chemical species.
+        legend_labels: List of strings for legend labels.
+
+    Attributes:
+        species_names: List of strings of names for all num_species_full chemical species.
+        legend_labels: List of strings for legend labels.
+        vis_type: String indicating the type of plot that this Visualization will represent, e.g. "field"
+        num_subplots: Number of subplots within figure.
+        vis_x_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            x-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        vis_y_bounds:
+            List of num_subplots lists, each of length 2 including lower and upper bounds on the
+            y-axis for each subplot. Setting to [None, None] allows for dynamic axis sizing.
+        num_rows: Number of rows in subplot grid within figure.
+        num_cols: Number of columns in subplot grid within figure.
+        ax_labels: List of num_subplots strings for label of each subplot's y-axis.
+    """
+
     def __init__(self, vis_id, vis_vars, vis_x_bounds, vis_y_bounds, species_names, legend_labels=None):
 
         self.species_names = species_names
@@ -23,7 +57,7 @@ class Visualization:
 
         if self.vis_type in ["field", "probe"]:
 
-            # check requested variables
+            # Check requested variables
             self.vis_vars = vis_vars
             for vis_var in self.vis_vars:
                 if vis_var in ["pressure", "velocity", "temperature", "source", "density", "momentum", "energy"]:
@@ -50,10 +84,8 @@ class Visualization:
 
             self.num_subplots = len(self.vis_vars)
 
-        # residual plot
         else:
-            self.vis_vars = ["residual"]
-            self.num_subplots = 1
+            raise ValueError("Invalid value for vis_type: " + str(self.vis_type))
 
         self.vis_x_bounds = vis_x_bounds
         assert len(self.vis_x_bounds) == self.num_subplots, (
@@ -77,13 +109,12 @@ class Visualization:
             self.num_rows = 3
             self.num_cols = 2
         elif self.num_subplots <= 9:
-            # TODO: an extra, empty subplot shows up with 7 subplots
             self.num_rows = 3
             self.num_cols = 3
         else:
             raise ValueError("Cannot plot more than nine" + " subplots in the same image")
 
-        # axis labels
+        # Axis labels
         # TODO: could change this to a dictionary reference
         self.ax_labels = [None] * self.num_subplots
         if self.vis_type == "residual":
@@ -97,7 +128,6 @@ class Visualization:
                     self.ax_labels[ax_idx] = r"Velocity $\left( \frac{m}{s} \right)$"
                 elif var_str == "temperature":
                     self.ax_labels[ax_idx] = r"Temperature $\left( K \right)$"
-                # TODO: source term needs to be generalized for multi-species
                 elif var_str == "source":
                     self.ax_labels[ax_idx] = r"Source Term $\left( \frac{kg}{m^3 \; s} \right)$"
                 elif var_str == "density":

--- a/perform/visualization/visualization_group.py
+++ b/perform/visualization/visualization_group.py
@@ -1,8 +1,6 @@
 from time import sleep
 
-import matplotlib
 import matplotlib.pyplot as plt
-import numpy as np
 
 from perform.constants import FIG_WIDTH_DEFAULT, FIG_HEIGHT_DEFAULT
 from perform.visualization.field_plot import FieldPlot
@@ -17,7 +15,7 @@ class VisualizationGroup:
     Container class for visualizations to be generated.
 
     Reads input parameters and initializes an arbitrary number of Visualization objects for plotting data.
-    
+
     Provides utility functions for updating, drawing, and saving these visualizations during simulation runtime.
 
     Child classes must implement plot() and save() member functions.
@@ -131,7 +129,7 @@ class VisualizationGroup:
 
         Loops through Visualization objects and draws, displays, and/or saves visualization plots
         at the physical time step interval specified by vis_interval.
-        
+
         Args:
             sol_domain: SolutionDomain with which this VisualizationGroup is associated.
             solver: SystemSolver containing global simulation parameters.

--- a/perform/visualization/visualization_group.py
+++ b/perform/visualization/visualization_group.py
@@ -9,10 +9,29 @@ from perform.visualization.field_plot import FieldPlot
 from perform.visualization.probe_plot import ProbePlot
 from perform.input_funcs import catch_input, catch_list
 
+# TODO: must adjust these functions for handling multiple SolutionDomains
+
 
 class VisualizationGroup:
     """
-    Container class for all visualizations
+    Container class for visualizations to be generated.
+
+    Reads input parameters and initializes an arbitrary number of Visualization objects for plotting data.
+    
+    Provides utility functions for updating, drawing, and saving these visualizations during simulation runtime.
+
+    Child classes must implement plot() and save() member functions.
+
+    Args:
+        sol_domain: SolutionDomain with which this VisualizationGroup is associated.
+        solver: SystemSolver containing global simulation parameters.
+
+    Attributes:
+        vis_show: Boolean flag indicating whether to display visualization plots on the user's screen.
+        vis_save: Boolean flag indicating whether to save visualization plot images to disk.
+        vis_interval: Physical time step interval at which to display/save visualization plots.
+        num_vis_plots: Total number of visualization figures.
+        vis_list: List containing Visualization objects to be plotted.
     """
 
     def __init__(self, sol_domain, solver):
@@ -22,7 +41,6 @@ class VisualizationGroup:
         self.vis_show = catch_input(param_dict, "vis_show", True)
         self.vis_save = catch_input(param_dict, "vis_save", False)
         self.vis_interval = catch_input(param_dict, "vis_interval", 1)
-        self.nice_vis = catch_input(param_dict, "nice_vis", False)
 
         # If not saving or showing, don't even draw the plots
         self.vis_draw = True
@@ -53,7 +71,7 @@ class VisualizationGroup:
         # Initialize each figure object
         for vis_idx in range(1, self.num_vis_plots + 1):
 
-            # some parameters all plots have
+            # Some parameters all plots have
             vis_type = str(param_dict["vis_type_" + str(vis_idx)])
             vis_vars = catch_list(param_dict, "vis_var_" + str(vis_idx), [None])
             vis_x_bounds = catch_list(
@@ -109,8 +127,14 @@ class VisualizationGroup:
             plt.pause(0.001)
 
     def draw_plots(self, sol_domain, solver):
-        """
-        Helper function to draw, display, and save plots
+        """Draw, display, and save plots if requested.
+
+        Loops through Visualization objects and draws, displays, and/or saves visualization plots
+        at the physical time step interval specified by vis_interval.
+        
+        Args:
+            sol_domain: SolutionDomain with which this VisualizationGroup is associated.
+            solver: SystemSolver containing global simulation parameters.
         """
 
         if not self.vis_draw:
@@ -128,7 +152,7 @@ class VisualizationGroup:
 
             for vis in self.vis_list:
 
-                # draw and save plots
+                # Draw and save plots
                 if vis.vis_type == "field":
                     vis.plot(
                         sol_domain.sol_int.sol_prim,

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,21 @@
 from setuptools import setup
 
-with open('README.md') as f:
-	readme = f.read()
+with open("README.md") as f:
+    readme = f.read()
 
-with open('LICENSE') as f:
-	license = f.read()
+with open("LICENSE") as f:
+    license = f.read()
 
 setup(
-	name = "PERFORM",
-	version = 0.1,
-	author = "Christopher R. Wentland",
-	author_email = "chriswen@umich.edu",
-	url = "https://github.com/cwentland0/pyGEMS_1D", 
-	description = "One-dimension reacting flow for ROM prototyping",
-	long_description = readme,
-	license = license,
-	install_requires = ['numpy>=1.16.6', 'scipy>=1.1.0', 'matplotlib>=2.1.0'],
-	entry_points = {'console_scripts': ['perform = perform.driver:main']},
-	python_requires = ">=3.6",
+    name="PERFORM",
+    version=0.1,
+    author="Christopher R. Wentland",
+    author_email="chriswen@umich.edu",
+    url="https://github.com/cwentland0/pyGEMS_1D",
+    description="One-dimension reacting flow for ROM prototyping",
+    long_description=readme,
+    license=license,
+    install_requires=["numpy>=1.16.6", "scipy>=1.1.0", "matplotlib>=2.1.0"],
+    entry_points={"console_scripts": ["perform = perform.driver:main"]},
+    python_requires=">=3.6",
 )

--- a/utils/calc_mean_flow_conditions.py
+++ b/utils/calc_mean_flow_conditions.py
@@ -1,5 +1,4 @@
 import os
-from math import sqrt
 
 import numpy as np
 

--- a/utils/gen_pod_basis.py
+++ b/utils/gen_pod_basis.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.linalg import svd
 
 
-##### BEGIN USER INPUT #####
+# ----- BEGIN USER INPUT -----
 
 data_dir = "~/path/to/data/dir"
 data_file = "sol_prim_FOM.npy"
@@ -26,7 +26,7 @@ max_modes = 25
 
 out_dir = "~/path/to/output/dir"
 
-##### END USER INPUT #####
+# ----- END USER INPUT -----
 
 out_dir = os.path.expanduser(out_dir)
 if not os.path.isdir(out_dir):


### PR DESCRIPTION
This PR addresses the very sparse docstrings for all modules, adding high-level descriptions for more complex classes and methods, as well as argument, attribute, and return value descriptions for all methods. Docstring formatting follows the Google format. Also configures flake8 for linting.

This does not address including API documentation in RTD (#30) but makes a strong step towards that. I tried testing this in RTD and frankly it looked like junk, but that's a task for another day.

Closes #29 