### PR TITLE
Fix broken ROM samples

### DIFF
--- a/examples/standing_flame/setup_sample_rom.sh
+++ b/examples/standing_flame/setup_sample_rom.sh
@@ -27,7 +27,7 @@ unzip -q standing_flame_linear_splsvt_proj_rom_sample.zip
 mv sol_prim_init_20mus.npy ./inputs
 
 # set path to model_dir
-sed -i "7s#.*#model_dir      = \"${PWD}/sample_pod_data\"#" rom_params.inp
+sed -i "9s#.*#model_dir      = \"${PWD}/sample_pod_data\"#" rom_params.inp
 
 rm standing_flame_linear_splsvt_proj_rom_sample.zip
 

--- a/examples/transient_flame/setup_sample_rom.sh
+++ b/examples/transient_flame/setup_sample_rom.sh
@@ -27,7 +27,7 @@ unzip -q transient_flame_autoencoder_splsvt_proj_tfkeras_rom_sample.zip
 mv sol_prim_init_100mus.npy ./inputs
 
 # set path to model_dir
-sed -i "9s#.*#model_dir      = \"${PWD}/sample_cae_data\"#" rom_params.inp
+sed -i "12s#.*#model_dir      = \"${PWD}/sample_cae_data\"#" rom_params.inp
 
 rm transient_flame_autoencoder_splsvt_proj_tfkeras_rom_sample.zip
 

--- a/perform/rom/rom_space_mapping/autoencoder_space_mapping.py
+++ b/perform/rom/rom_space_mapping/autoencoder_space_mapping.py
@@ -23,7 +23,7 @@ class AutoencoderSpaceMapping(RomSpaceMapping):
         assert os.path.isfile(in_file), "Could not find decoder file at " + in_file
         self.decoder_file = in_file
         self.decoder_isconv = catch_input(rom_dict, "decoder_isconv", False)
-        self.decoder_io_format = catch_input(rom_dict, "model_io_format", None)
+        self.decoder_io_format = catch_input(rom_dict, "decoder_io_format", None)
 
         # If required, encoder input checking
         self.encoder_file = None


### PR DESCRIPTION
Standing flame linear ROM and transient flame autoencoder ROM used outdated parameter names in `rom_params.inp`. Uploaded new zip files to Google Drive and updated Bash scripts for downloading and unpacking.

Also, changed `model_is_conv` to `decoder_io_format` in `autoencoder_space_mapping`, I thought I had updated that but I guess not.