### PR TITLE
Probes include initial conditions, correct output for non-solution fields/probes

### DIFF
--- a/examples/standing_flame/solver_params.inp
+++ b/examples/standing_flame/solver_params.inp
@@ -46,7 +46,7 @@ out_interval = 1
 prim_out     = True
 cons_out     = True
 source_out   = False
-rhs_outut    = False
+rhs_out      = False
 
 # probe output
 probe_locs = [0.0025, 0.0075]

--- a/perform/driver.py
+++ b/perform/driver.py
@@ -49,6 +49,12 @@ def driver(working_dir):
     # ----- Start unsteady solution -----
 
     try:
+
+        # run RHS calculation and update solution probes to store IC data correctly
+        solver.iter = 0
+        sol_domain.update_probes(solver, is_sol_data=True)
+        sol_domain.calc_rhs(solver)
+
         # Loop over time iterations
         time_start = time()
         for solver.iter in range(1, solver.num_steps + 1):
@@ -62,7 +68,7 @@ def driver(working_dir):
             solver.sol_time += solver.dt
 
             # Write unsteady solution outputs
-            sol_domain.write_iter_outputs(solver)
+            sol_domain.write_sol_outputs(solver)
 
             # Check "steady" solve
             if solver.run_steady:
@@ -85,6 +91,13 @@ def driver(working_dir):
     # ----- End unsteady solution -----
 
     # ----- Start post-processing -----
+
+    # Run RHS calculations one more time to get non-solution data at final snapshot, if necessary
+    # TODO: jank, could just pass an iteration number to write_nonsol_outputs
+    sol_domain.calc_rhs(solver)
+    solver.iter += 1
+    sol_domain.write_nonsol_outputs(solver)
+    solver.iter -= 1
 
     sol_domain.write_final_outputs(solver)
 

--- a/tests/integration_tests/test_solution/test_solution_interior.py
+++ b/tests/integration_tests/test_solution/test_solution_interior.py
@@ -135,12 +135,12 @@ class SolutionIntMethodsTestCase(unittest.TestCase):
         self.assertTrue(np.array_equal(self.sol.prim_snap, np.repeat(self.sol.sol_prim[:, :, None], 6, axis=2)))
         self.assertTrue(np.array_equal(self.sol.cons_snap, np.repeat(self.sol.sol_cons[:, :, None], 6, axis=2)))
         self.assertTrue(
-            np.array_equal(self.sol.reaction_source_snap, np.repeat(self.sol.reaction_source[:, :, None], 5, axis=2))
+            np.array_equal(self.sol.reaction_source_snap, np.repeat(self.sol.reaction_source[:, :, None], 6, axis=2))
         )
         self.assertTrue(
-            np.array_equal(self.sol.heat_release_snap, np.repeat(self.sol.heat_release[:, None], 5, axis=1))
+            np.array_equal(self.sol.heat_release_snap, np.repeat(self.sol.heat_release[:, None], 6, axis=1))
         )
-        self.assertTrue(np.array_equal(self.sol.rhs_snap, np.repeat(self.sol.rhs[:, :, None], 5, axis=2)))
+        self.assertTrue(np.array_equal(self.sol.rhs_snap, np.repeat(self.sol.rhs[:, :, None], 6, axis=2)))
 
     def test_snapshot_output(self):
 
@@ -174,12 +174,12 @@ class SolutionIntMethodsTestCase(unittest.TestCase):
                 self.assertTrue(np.array_equal(sol_prim_itmdt, np.repeat(self.sol.sol_prim[:, :, None], 3, axis=2)))
                 self.assertTrue(np.array_equal(sol_cons_itmdt, np.repeat(self.sol.sol_cons[:, :, None], 3, axis=2)))
                 self.assertTrue(
-                    np.array_equal(source_itmdt, np.repeat(self.sol.reaction_source[:, :, None], 2, axis=2))
+                    np.array_equal(source_itmdt, np.repeat(self.sol.reaction_source[:, :, None], 3, axis=2))
                 )
                 self.assertTrue(
-                    np.array_equal(heat_release_itmdt, np.repeat(self.sol.heat_release[:, None], 2, axis=1))
+                    np.array_equal(heat_release_itmdt, np.repeat(self.sol.heat_release[:, None], 3, axis=1))
                 )
-                self.assertTrue(np.array_equal(rhs_itmdt, np.repeat(self.sol.rhs[:, :, None], 2, axis=2)))
+                self.assertTrue(np.array_equal(rhs_itmdt, np.repeat(self.sol.rhs[:, :, None], 3, axis=2)))
 
             # write and check "failed" snapshots
             if self.solver.iter == 7:
@@ -205,12 +205,12 @@ class SolutionIntMethodsTestCase(unittest.TestCase):
                 self.assertTrue(np.array_equal(sol_prim_failed, np.repeat(self.sol.sol_prim[:, :, None], 4, axis=2)))
                 self.assertTrue(np.array_equal(sol_cons_failed, np.repeat(self.sol.sol_cons[:, :, None], 4, axis=2)))
                 self.assertTrue(
-                    np.array_equal(source_failed, np.repeat(self.sol.reaction_source[:, :, None], 3, axis=2))
+                    np.array_equal(source_failed, np.repeat(self.sol.reaction_source[:, :, None], 4, axis=2))
                 )
                 self.assertTrue(
-                    np.array_equal(heat_release_failed, np.repeat(self.sol.heat_release[:, None], 3, axis=1))
+                    np.array_equal(heat_release_failed, np.repeat(self.sol.heat_release[:, None], 4, axis=1))
                 )
-                self.assertTrue(np.array_equal(rhs_failed, np.repeat(self.sol.rhs[:, :, None], 3, axis=2)))
+                self.assertTrue(np.array_equal(rhs_failed, np.repeat(self.sol.rhs[:, :, None], 4, axis=2)))
 
         # delete intermediate results and check that they deleted properly
         self.sol.delete_itmdt_snapshots(self.solver)
@@ -253,9 +253,9 @@ class SolutionIntMethodsTestCase(unittest.TestCase):
         rhs_final = np.load(os.path.join(self.solver.unsteady_output_dir, "rhs_" + self.solver.sim_type + ".npy"))
         self.assertTrue(np.array_equal(sol_prim_final, np.repeat(self.sol.sol_prim[:, :, None], 6, axis=2)))
         self.assertTrue(np.array_equal(sol_cons_final, np.repeat(self.sol.sol_cons[:, :, None], 6, axis=2)))
-        self.assertTrue(np.array_equal(source_final, np.repeat(self.sol.reaction_source[:, :, None], 5, axis=2)))
-        self.assertTrue(np.array_equal(heat_release_final, np.repeat(self.sol.heat_release[:, None], 5, axis=1)))
-        self.assertTrue(np.array_equal(rhs_final, np.repeat(self.sol.rhs[:, :, None], 5, axis=2)))
+        self.assertTrue(np.array_equal(source_final, np.repeat(self.sol.reaction_source[:, :, None], 6, axis=2)))
+        self.assertTrue(np.array_equal(heat_release_final, np.repeat(self.sol.heat_release[:, None], 6, axis=1)))
+        self.assertTrue(np.array_equal(rhs_final, np.repeat(self.sol.rhs[:, :, None], 6, axis=2)))
 
     def test_write_restart_file(self):
 


### PR DESCRIPTION
This PR addresses two previous deficiencies:
1. Probe monitors now include the initial conditions. 
2. Non-solution variables (specifically those from the RHS calculations, such as the heat release or source terms) were previously output from their evaluation at the second-to-last subiteration of the previous outer iteration, not at the current solution. Further, the output did not include these functions evaluated at the initial conditions. This has been corrected.

Closes #40 